### PR TITLE
REALMC-6847: fix iterator off-by-one bug

### DIFF
--- a/array_test.go
+++ b/array_test.go
@@ -1,33 +1,33 @@
 package otto
 
 import (
-    "strings"
-    "testing"
+	"strings"
+	"testing"
 )
 
 func TestArray(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             var abc = [ undefined, "Nothing happens." ];
             abc.length;
         `, 2)
 
-        test(`
+		test(`
             abc = ""+[0, 1, 2, 3];
             def = [].toString();
             ghi = [null, 4, "null"].toString();
             [ abc, def, ghi ];
         `, "0,1,2,3,,,4,null")
 
-        test(`new Array(0).length`, 0)
+		test(`new Array(0).length`, 0)
 
-        test(`new Array(11).length`, 11)
+		test(`new Array(11).length`, 11)
 
-        test(`new Array(11, 1).length`, 2)
+		test(`new Array(11, 1).length`, 2)
 
-        test(`
+		test(`
             abc = [0, 1, 2, 3];
             abc.xyzzy = "Nothing happens.";
             delete abc[1];
@@ -35,21 +35,21 @@ func TestArray(t *testing.T) {
             [ abc, xyzzy, abc.xyzzy ];
         `, "0,,2,3,true,")
 
-        test(`
+		test(`
             var abc = [0, 1, 2, 3, 4];
             abc.length = 2;
             abc;
         `, "0,1")
 
-        test(`raise:
+		test(`raise:
             [].length = 3.14159;
         `, "RangeError")
 
-        test(`raise:
+		test(`raise:
             new Array(3.14159);
         `, "RangeError")
 
-        test(`
+		test(`
             Object.defineProperty(Array.prototype, "0", {
                 value: 100,
                 writable: false,
@@ -59,23 +59,23 @@ func TestArray(t *testing.T) {
             abc.hasOwnProperty("0") && abc[0] === 101;
         `, true)
 
-        test(`
+		test(`
             abc = [,,undefined];
             [ abc.hasOwnProperty(0), abc.hasOwnProperty(1), abc.hasOwnProperty(2) ];
         `, "false,false,true")
 
-        test(`
+		test(`
             abc = Object.getOwnPropertyDescriptor(Array, "prototype");
             [   [ typeof Array.prototype ],
                 [ abc.writable, abc.enumerable, abc.configurable ] ];
         `, "object,false,false,false")
-    })
+	})
 }
 
 func TestArray_toString(t *testing.T) {
-    tt(t, func() {
-        {
-            test(`
+	tt(t, func() {
+		{
+			test(`
                 Array.prototype.toString = function() {
                     return "Nothing happens.";
                 }
@@ -85,10 +85,10 @@ func TestArray_toString(t *testing.T) {
 
                 [ abc, def, ghi ].join(",");
             `, "Nothing happens.,Nothing happens.,Nothing happens.")
-        }
+		}
 
-        {
-            test(`
+		{
+			test(`
                 Array.prototype.join = undefined
                 abc = Array.prototype.toString()
                 def = [].toString()
@@ -96,15 +96,15 @@ func TestArray_toString(t *testing.T) {
 
                 abc + "," + def + "," + ghi;
             `, "[object Array],[object Array],[object Array]")
-        }
-    })
+		}
+	})
 }
 
 func TestArray_iterator(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             var iterator = [1, 2, 3]["Symbol(Symbol.iterator)"]();
             one = iterator.next().value
             two = iterator.next().value
@@ -113,16 +113,17 @@ func TestArray_iterator(t *testing.T) {
             one + "," + two + "," + three
         `, "1,2,3")
 
-        test(`
+		test(`
             var iterator = [1, 2, 3]["Symbol(Symbol.iterator)"]();
             one = iterator.next().done
             two = iterator.next().done
             three = iterator.next().done
+            end = iterator.next().done
 
-            one + "," + two + "," + three
-        `, "false,false,true")
+            one + "," + two + "," + three + "," + end
+        `, "false,false,false,true")
 
-        test(`
+		test(`
             var iterator = []["Symbol(Symbol.iterator)"]();
             res = iterator.next()
             val = res.value
@@ -130,36 +131,36 @@ func TestArray_iterator(t *testing.T) {
 
             val + "," + done
         `, "undefined,true")
-    })
+	})
 }
 
 func TestArray_toLocaleString(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        defer mockUTC()()
+		defer mockUTC()()
 
-        test(`
+		test(`
             [ 3.14159, "abc", undefined, new Date(0) ].toLocaleString();
         `, "3.14159,abc,,1970-01-01 00:00:00")
 
-        test(`
+		test(`
                 var arr = [ 3.14159, "abc", undefined, new Date(0) ];
                 arr.length = 10;
                 arr.toLocaleString();
             `, "3.14159,abc,,1970-01-01 00:00:00,,,,,,")
 
-        test(`raise:
+		test(`raise:
             [ { toLocaleString: undefined } ].toLocaleString();
         `, "TypeError")
-    })
+	})
 }
 
 func TestArray_concat(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             abc = [0, 1, 2];
             def = [-1, -2, -3];
             ghi = abc.concat(def);
@@ -169,7 +170,7 @@ func TestArray_concat(t *testing.T) {
             [ ghi, jkl, mno ].join(";");
         `, "0,1,2,-1,-2,-3;0,1,2,-1,-2,-3,3,4,5;-1,-2,-3,-4,-5,0,1,2")
 
-        test(`
+		test(`
             var abc = [,1];
             var def = abc.concat([], [,]);
 
@@ -178,7 +179,7 @@ func TestArray_concat(t *testing.T) {
             [ def.getClass(), typeof def[0], def[1], typeof def[2], def.length ];
         `, "[object Array],undefined,1,undefined,3")
 
-        test(`
+		test(`
             Object.defineProperty(Array.prototype, "0", {
                 value: 100,
                 writable: false,
@@ -209,14 +210,14 @@ func TestArray_concat(t *testing.T) {
 
             [ hasProperty, instanceOfVerify, verifyValue, !verifyConfigurable, verifyEnumerable, verifyWritable ];
         `, "true,true,true,true,true,true")
-    })
+	})
 }
 
 func TestArray_splice(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             abc = [0, 1, 2];
             def = abc.splice(1, 2, 3, 4, 5);
             ghi = [].concat(abc);
@@ -225,14 +226,14 @@ func TestArray_splice(t *testing.T) {
             pqr = mno.splice(2);
             [ abc, def, ghi, jkl, mno, pqr ].join(";");
         `, "0,3,4,5;1,2;0,3,4,5,7,8,9;;0,3;4,5")
-    })
+	})
 }
 
 func TestArray_shift(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             abc = [0, 1, 2];
             def = abc.shift();
             ghi = [].concat(abc);
@@ -244,14 +245,14 @@ func TestArray_shift(t *testing.T) {
 
             [ abc, def, ghi, jkl, mno, pqr, stu, vwx ].join(";");
         `, ";0;1,2;1;2;2;;")
-    })
+	})
 }
 
 func TestArray_push(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             abc = [0];
             def = abc.push(1);
             ghi = [].concat(abc);
@@ -259,14 +260,14 @@ func TestArray_push(t *testing.T) {
 
             [ abc, def, ghi, jkl ].join(";");
         `, "0,1,2,3,4;2;0,1;5")
-    })
+	})
 }
 
 func TestArray_pop(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             abc = [0,1];
             def = abc.pop();
             ghi = [].concat(abc);
@@ -276,14 +277,14 @@ func TestArray_pop(t *testing.T) {
 
             [ abc, def, ghi, jkl, mno, pqr ].join(";");
         `, ";1;0;0;;")
-    })
+	})
 }
 
 func TestArray_slice(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             abc = [0,1,2,3];
             def = abc.slice();
             ghi = abc.slice(1);
@@ -296,8 +297,8 @@ func TestArray_slice(t *testing.T) {
             [ abc, def, ghi, jkl, mno, pqr, stu ].join(";");
         `, "0,1,2,3,,,,,,;0,1,2,3;1,2,3;;2;;2,3,,,,,")
 
-        // Array.protoype.slice is generic
-        test(`
+		// Array.protoype.slice is generic
+		test(`
             abc = { 0: 0, 1: 1, 2: 2, 3: 3 };
             abc.length = 4;
             def = Array.prototype.slice.call(abc);
@@ -308,26 +309,26 @@ func TestArray_slice(t *testing.T) {
 
             [ abc, def, ghi, jkl, pqr ].join(";");
         `, "[object Object];0,1,2,3;1,2,3;;")
-    })
+	})
 }
 
 func TestArray_sliceArguments(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             (function(){
                 return Array.prototype.slice.call(arguments, 1)
             })({}, 1, 2, 3);
         `, "1,2,3")
-    })
+	})
 }
 
 func TestArray_unshift(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             abc = [];
             def = abc.unshift(0);
             ghi = [].concat(abc);
@@ -335,27 +336,27 @@ func TestArray_unshift(t *testing.T) {
 
             [ abc, def, ghi, jkl ].join(";");
         `, "1,2,3,4,0;1;0;5")
-    })
+	})
 }
 
 func TestArray_reverse(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             abc = [0,1,2,3].reverse();
             def = [0,1,2].reverse();
 
             [ abc, def ];
         `, "3,2,1,0,2,1,0")
-    })
+	})
 }
 
 func TestArray_sort(t *testing.T) {
-    tt(t, func() {
-        test, vm := test()
+	tt(t, func() {
+		test, vm := test()
 
-        test(`
+		test(`
             abc = [0,1,2,3].sort();
             def = [3,2,1,0].sort();
             ghi = [].sort();
@@ -371,140 +372,140 @@ func TestArray_sort(t *testing.T) {
             [ abc, def, ghi, jkl, mno, pqr, stu, vwx, yza ].join(";");
         `, "0,1,2,3;0,1,2,3;;0;0,1;-10,0.05,1,100,401,5,72,8;-10,0.05,1,5,8,72,100,401;1,1,2,2,3,3;-1,0,0,1,1,1,2,3")
 
-        test(`Array.prototype.sort.length`, 1)
+		test(`Array.prototype.sort.length`, 1)
 
-        // inject quicksort code
-        _, err := vm.Run(jsQuickSort)
-        is(err, nil)
+		// inject quicksort code
+		_, err := vm.Run(jsQuickSort)
+		is(err, nil)
 
-        testSlice := []Value{toValue(5), toValue(3), toValue(2), toValue(4), toValue(1)}
-        vm.Set("testSlice", testSlice)
-        _, err = vm.Run("quickSort(testSlice, 0, testSlice.length-1);")
-        is(err, nil)
+		testSlice := []Value{toValue(5), toValue(3), toValue(2), toValue(4), toValue(1)}
+		vm.Set("testSlice", testSlice)
+		_, err = vm.Run("quickSort(testSlice, 0, testSlice.length-1);")
+		is(err, nil)
 
-        is(test(`testSlice[0]`).export(), 1)
-        is(test(`testSlice[1]`).export(), 2)
-        is(test(`testSlice[2]`).export(), 3)
-        is(test(`testSlice[3]`).export(), 4)
-        is(test(`testSlice[4]`).export(), 5)
+		is(test(`testSlice[0]`).export(), 1)
+		is(test(`testSlice[1]`).export(), 2)
+		is(test(`testSlice[2]`).export(), 3)
+		is(test(`testSlice[3]`).export(), 4)
+		is(test(`testSlice[4]`).export(), 5)
 
-        is(testSlice[0], 1)
-        is(testSlice[1], 2)
-        is(testSlice[2], 3)
-        is(testSlice[3], 4)
-        is(testSlice[4], 5)
-    })
+		is(testSlice[0], 1)
+		is(testSlice[1], 2)
+		is(testSlice[2], 3)
+		is(testSlice[3], 4)
+		is(testSlice[4], 5)
+	})
 }
 
 func TestArray_isArray(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
         [ Array.isArray.length, Array.isArray(), Array.isArray([]), Array.isArray({}) ];
         `, "1,false,true,false")
 
-        test(`Array.isArray(Math)`, false)
-    })
+		test(`Array.isArray(Math)`, false)
+	})
 }
 
 func TestArray_indexOf(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`['a', 'b', 'c', 'b'].indexOf('b')`, 1)
+		test(`['a', 'b', 'c', 'b'].indexOf('b')`, 1)
 
-        test(`['a', 'b', 'c', 'b'].indexOf('b', 2)`, 3)
+		test(`['a', 'b', 'c', 'b'].indexOf('b', 2)`, 3)
 
-        test(`['a', 'b', 'c', 'b'].indexOf('b', -2)`, 3)
+		test(`['a', 'b', 'c', 'b'].indexOf('b', -2)`, 3)
 
-        test(`
+		test(`
             Object.prototype.indexOf = Array.prototype.indexOf;
             var abc = {0: 'a', 1: 'b', 2: 'c', length: 3};
             abc.indexOf('c');
         `, 2)
 
-        test(`[true].indexOf(true, "-Infinity")`, 0)
+		test(`[true].indexOf(true, "-Infinity")`, 0)
 
-        test(`
+		test(`
             var target = {};
             Math[3] = target;
             Math.length = 5;
             Array.prototype.indexOf.call(Math, target) === 3;
         `, true)
 
-        test(`
+		test(`
             var _NaN = NaN;
             var abc = new Array("NaN", undefined, 0, false, null, {toString:function(){return NaN}}, "false", _NaN, NaN);
             abc.indexOf(NaN);
         `, -1)
 
-        test(`
+		test(`
             var abc = {toString:function (){return 0}};
             var def = 1;
             var ghi = -(4/3);
             var jkl = new Array(false, undefined, null, "0", abc, -1.3333333333333, "string", -0, true, +0, def, 1, 0, false, ghi, -(4/3));
             [ jkl.indexOf(-(4/3)), jkl.indexOf(0), jkl.indexOf(-0), jkl.indexOf(1) ];
         `, "14,7,7,10")
-    })
+	})
 }
 
 func TestArray_lastIndexOf(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`['a', 'b', 'c', 'b'].lastIndexOf('b')`, 3)
+		test(`['a', 'b', 'c', 'b'].lastIndexOf('b')`, 3)
 
-        test(`['a', 'b', 'c', 'b'].lastIndexOf('b', 2)`, 1)
+		test(`['a', 'b', 'c', 'b'].lastIndexOf('b', 2)`, 1)
 
-        test(`['a', 'b', 'c', 'b'].lastIndexOf('b', -2)`, 1)
+		test(`['a', 'b', 'c', 'b'].lastIndexOf('b', -2)`, 1)
 
-        test(`
+		test(`
             Object.prototype.lastIndexOf = Array.prototype.lastIndexOf;
             var abc = {0: 'a', 1: 'b', 2: 'c', 3: 'b', length: 4};
             abc.lastIndexOf('b');
         `, 3)
 
-        test(`
+		test(`
             var target = {};
             Math[3] = target;
             Math.length = 5;
             [ Array.prototype.lastIndexOf.call(Math, target) === 3 ];
         `, "true")
 
-        test(`
+		test(`
             var _NaN = NaN;
             var abc = new Array("NaN", undefined, 0, false, null, {toString:function(){return NaN}}, "false", _NaN, NaN);
             abc.lastIndexOf(NaN);
         `, -1)
 
-        test(`
+		test(`
             var abc = {toString:function (){return 0}};
             var def = 1;
             var ghi = -(4/3);
             var jkl = new Array(false, undefined, null, "0", abc, -1.3333333333333, "string", -0, true, +0, def, 1, 0, false, ghi, -(4/3));
             [ jkl.lastIndexOf(-(4/3)), jkl.indexOf(0), jkl.indexOf(-0), jkl.indexOf(1) ];
         `, "15,7,7,10")
-    })
+	})
 }
 
 func TestArray_every(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`raise: [].every()`, "TypeError")
+		test(`raise: [].every()`, "TypeError")
 
-        test(`raise: [].every("abc")`, "TypeError")
+		test(`raise: [].every("abc")`, "TypeError")
 
-        test(`[].every(function() { return false })`, true)
+		test(`[].every(function() { return false })`, true)
 
-        test(`[1,2,3].every(function() { return false })`, false)
+		test(`[1,2,3].every(function() { return false })`, false)
 
-        test(`[1,2,3].every(function() { return true })`, true)
+		test(`[1,2,3].every(function() { return true })`, true)
 
-        test(`[1,2,3].every(function(_, index) { if (index === 1) return true })`, false)
+		test(`[1,2,3].every(function(_, index) { if (index === 1) return true })`, false)
 
-        test(`
+		test(`
             var abc = function(value, index, object) {
                 return ('[object Math]' !== Object.prototype.toString.call(object));
             };
@@ -514,7 +515,7 @@ func TestArray_every(t *testing.T) {
             !Array.prototype.every.call(Math, abc);
         `, true)
 
-        test(`
+		test(`
             var def = false;
 
             var abc = function(value, index, object) {
@@ -525,7 +526,7 @@ func TestArray_every(t *testing.T) {
             [11].every(abc, Math) && def;
         `, true)
 
-        test(`
+		test(`
             var def = false;
 
             var abc = function(value, index, object) {
@@ -535,24 +536,24 @@ func TestArray_every(t *testing.T) {
 
             [11].every(abc) && def;
         `, true)
-    })
+	})
 }
 
 func TestArray_some(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`raise: [].some("abc")`, "TypeError")
+		test(`raise: [].some("abc")`, "TypeError")
 
-        test(`[].some(function() { return true })`, false)
+		test(`[].some(function() { return true })`, false)
 
-        test(`[1,2,3].some(function() { return false })`, false)
+		test(`[1,2,3].some(function() { return false })`, false)
 
-        test(`[1,2,3].some(function() { return true })`, true)
+		test(`[1,2,3].some(function() { return true })`, true)
 
-        test(`[1,2,3].some(function(_, index) { if (index === 1) return true })`, true)
+		test(`[1,2,3].some(function(_, index) { if (index === 1) return true })`, true)
 
-        test(`
+		test(`
             var abc = function(value, index, object) {
                 return ('[object Math]' !== Object.prototype.toString.call(object));
             };
@@ -562,7 +563,7 @@ func TestArray_some(t *testing.T) {
             !Array.prototype.some.call(Math, abc);
         `, true)
 
-        test(`
+		test(`
             var abc = function(value, index, object) {
                 return this === Math;
             };
@@ -570,23 +571,23 @@ func TestArray_some(t *testing.T) {
             [11].some(abc, Math);
         `, true)
 
-        test(`
+		test(`
             var abc = function(value, index, object) {
                 return Math;
             };
 
             [11].some(abc);
         `, true)
-    })
+	})
 }
 
 func TestArray_forEach(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`raise: [].forEach("abc")`, "TypeError")
+		test(`raise: [].forEach("abc")`, "TypeError")
 
-        test(`
+		test(`
             var abc = 0;
             [].forEach(function(value) {
                 abc += value;
@@ -594,7 +595,7 @@ func TestArray_forEach(t *testing.T) {
             abc;
         `, 0)
 
-        test(`
+		test(`
             abc = 0;
             var def = [];
             [1,2,3].forEach(function(value, index) {
@@ -604,7 +605,7 @@ func TestArray_forEach(t *testing.T) {
             [ abc, def ];
         `, "6,0,1,2")
 
-        test(`
+		test(`
             var def = false;
             var abc = function(value, index, object) {
                 def = ('[object Math]' === Object.prototype.toString.call(object));
@@ -616,7 +617,7 @@ func TestArray_forEach(t *testing.T) {
             def;
         `, true)
 
-        test(`
+		test(`
             var def = false;
             var abc = function(value, index, object) {
                 def = this === Math;
@@ -625,14 +626,14 @@ func TestArray_forEach(t *testing.T) {
             [11].forEach(abc, Math);
             def;
         `, true)
-    })
+	})
 }
 
 func TestArray_indexing(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             var abc = new Array(0, 1);
             var def = abc.length;
             abc[4294967296] = 10; // 2^32 => 0
@@ -640,7 +641,7 @@ func TestArray_indexing(t *testing.T) {
             [ def, abc.length, abc[0], abc[1], abc[4294967296] ];
         `, "2,2,0,1,10")
 
-        test(`
+		test(`
             abc = new Array(0, 1);
             def = abc.length;
             abc[4294967295] = 10;
@@ -650,22 +651,22 @@ func TestArray_indexing(t *testing.T) {
             abc[4294967294] = 11;
             [ def, ghi, jkl, abc.length, abc[4294967295], abc[4294967299] ];
         `, "2,2,2,4294967295,10,12")
-    })
+	})
 }
 
 func TestArray_map(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`raise: [].map("abc")`, "TypeError")
+		test(`raise: [].map("abc")`, "TypeError")
 
-        test(`[].map(function() { return 1 }).length`, 0)
+		test(`[].map(function() { return 1 }).length`, 0)
 
-        test(`[1,2,3].map(function(value) { return value * value })`, "1,4,9")
+		test(`[1,2,3].map(function(value) { return value * value })`, "1,4,9")
 
-        test(`[1,2,3].map(function(value) { return 1 })`, "1,1,1")
+		test(`[1,2,3].map(function(value) { return 1 })`, "1,1,1")
 
-        test(`
+		test(`
             var abc = function(value, index, object) {
                 return ('[object Math]' === Object.prototype.toString.call(object));
             };
@@ -675,7 +676,7 @@ func TestArray_map(t *testing.T) {
             Array.prototype.map.call(Math, abc)[0];
         `, true)
 
-        test(`
+		test(`
             var abc = function(value, index, object) {
                 return this === Math;
             };
@@ -683,81 +684,81 @@ func TestArray_map(t *testing.T) {
             [11].map(abc, Math)[0];
         `, true)
 
-        test(`
+		test(`
             var array1 = [1, 4, 9, 16];
             array1.length = 999;
             array1[7] = 25;
             array1.map(function(x) { return x * 2 });
         `, "2,8,18,32,,,,50"+strings.Repeat(",", 999-8))
-    })
+	})
 }
 
 func TestArray_filter(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`raise: [].filter("abc")`, "TypeError")
+		test(`raise: [].filter("abc")`, "TypeError")
 
-        test(`[].filter(function() { return 1 }).length`, 0)
+		test(`[].filter(function() { return 1 }).length`, 0)
 
-        test(`[1,2,3].filter(function() { return false }).length`, 0)
+		test(`[1,2,3].filter(function() { return false }).length`, 0)
 
-        test(`[1,2,3].filter(function() { return true })`, "1,2,3")
+		test(`[1,2,3].filter(function() { return true })`, "1,2,3")
 
-        test(`
+		test(`
             var array1 = [1, 4, 9, 16];
             array1.length = 999;
             array1[7] = 25;
             array1.filter(function(x) { return true });
         `, "1,4,9,16,,,,25"+strings.Repeat(",", 999-8))
-    })
+	})
 }
 
 func TestArray_reduce(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`raise: [].reduce("abc")`, "TypeError")
+		test(`raise: [].reduce("abc")`, "TypeError")
 
-        test(`raise: [].reduce(function() {})`, "TypeError")
+		test(`raise: [].reduce(function() {})`, "TypeError")
 
-        test(`[].reduce(function() {}, 0)`, 0)
+		test(`[].reduce(function() {}, 0)`, 0)
 
-        test(`[].reduce(function() {}, undefined)`, "undefined")
+		test(`[].reduce(function() {}, undefined)`, "undefined")
 
-        test(`['a','b','c'].reduce(function(result, value) { return result+', '+value })`, "a, b, c")
+		test(`['a','b','c'].reduce(function(result, value) { return result+', '+value })`, "a, b, c")
 
-        test(`[1,2,3].reduce(function(result, value) { return result + value }, 4)`, 10)
+		test(`[1,2,3].reduce(function(result, value) { return result + value }, 4)`, 10)
 
-        test(`[1,2,3].reduce(function(result, value) { return result + value })`, 6)
-    })
+		test(`[1,2,3].reduce(function(result, value) { return result + value })`, 6)
+	})
 }
 
 func TestArray_reduceRight(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`raise: [].reduceRight("abc")`, "TypeError")
+		test(`raise: [].reduceRight("abc")`, "TypeError")
 
-        test(`raise: [].reduceRight(function() {})`, "TypeError")
+		test(`raise: [].reduceRight(function() {})`, "TypeError")
 
-        test(`[].reduceRight(function() {}, 0)`, 0)
+		test(`[].reduceRight(function() {}, 0)`, 0)
 
-        test(`[].reduceRight(function() {}, undefined)`, "undefined")
+		test(`[].reduceRight(function() {}, undefined)`, "undefined")
 
-        test(`['a','b','c'].reduceRight(function(result, value) { return result+', '+value })`, "c, b, a")
+		test(`['a','b','c'].reduceRight(function(result, value) { return result+', '+value })`, "c, b, a")
 
-        test(`[1,2,3].reduceRight(function(result, value) { return result + value }, 4)`, 10)
+		test(`[1,2,3].reduceRight(function(result, value) { return result + value }, 4)`, 10)
 
-        test(`[1,2,3].reduceRight(function(result, value) { return result + value })`, 6)
-    })
+		test(`[1,2,3].reduceRight(function(result, value) { return result + value })`, 6)
+	})
 }
 
 func TestArray_defineOwnProperty(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             var abc = [];
             Object.defineProperty(abc, "length", {
                 writable: false
@@ -765,7 +766,7 @@ func TestArray_defineOwnProperty(t *testing.T) {
             abc.length;
         `, 0)
 
-        test(`raise:
+		test(`raise:
             var abc = [];
             var exception;
             Object.defineProperty(abc, "length", {
@@ -775,23 +776,23 @@ func TestArray_defineOwnProperty(t *testing.T) {
                 writable: true
             });
         `, "TypeError")
-    })
+	})
 }
 
 func TestArray_new(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             var abc = new Array(null);
             var def = new Array(undefined);
             [ abc.length, abc[0] === null, def.length, def[0] === undefined ]
         `, "1,true,1,true")
 
-        test(`
+		test(`
             var abc = new Array(new Number(0));
             var def = new Array(new Number(4294967295));
             [ abc.length, typeof abc[0], abc[0] == 0, def.length, typeof def[0], def[0] == 4294967295 ]
         `, "1,object,true,1,object,true")
-    })
+	})
 }

--- a/builtin_array.go
+++ b/builtin_array.go
@@ -626,7 +626,7 @@ func builtinArray_iterator(call FunctionCall) Value {
 		prototype:   call.runtime.global.FunctionPrototype,
 		extensible:  true,
 		property: map[string]_property{
-			"length": _property{
+			"length": {
 				mode: 0,
 				value: Value{
 					kind:  valueNumber,
@@ -651,7 +651,7 @@ func builtinArray_iterator(call FunctionCall) Value {
 		extensible:  true,
 		value:       nil,
 		property: map[string]_property{
-			"next": _property{
+			"next": {
 				mode: 0101,
 				value: Value{
 					kind:  valueObject,
@@ -669,6 +669,10 @@ func builtinArrayIterator_next(list []Value) func(call FunctionCall) Value {
 		if len(list) == 0 {
 			result.put("value", UndefinedValue(), false)
 			result.put("done", toValue_bool(true), false)
+		}
+
+		if index == len(list) {
+			result.put("done", toValue_bool(true), false)
 			return toValue_object(result)
 		}
 
@@ -676,9 +680,6 @@ func builtinArrayIterator_next(list []Value) func(call FunctionCall) Value {
 		result.put("done", toValue_bool(false), false)
 
 		index++
-		if index == len(list) {
-			result.put("done", toValue_bool(true), false)
-		}
 
 		return toValue_object(result)
 	}


### PR DESCRIPTION
## ✍️  Description

The issue we were having was with `for ...of` loops so that the following:

```javascript

exports = function(arg){
  const bugsList = context.values.get('valuesBugList');
 
  for (const bug of bugsList) {
    console.log(bug)
  }
};
```

would print every element but the last one. This was due to our implementation not reflecting the specs for iterators.

As we go over the iterable entity, these are the elements returned by the `.next()` method:

```javascript
{ value: "somevalue1", done: false }
{ value: "somevalue2", done: false }
{ value: "somevalue3", done: false }
{ value: "somevalue4", done: true }
```
Since the iterator stops as soon as an element has `done === true` we would skip the last element.

The correct behavior for `.next()` will produce:

```javascript
{ value: "somevalue1", done: false }
{ value: "somevalue2", done: false }
{ value: "somevalue3", done: false }
{ value: "somevalue4", done: false }
{ done: true }
```