### PR TITLE
REALMC-6847: fix iterator bug

### DIFF
--- a/array_test.go
+++ b/array_test.go
@@ -1,33 +1,33 @@
 package otto
 
 import (
-    "strings"
-    "testing"
+	"strings"
+	"testing"
 )
 
 func TestArray(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             var abc = [ undefined, "Nothing happens." ];
             abc.length;
         `, 2)
 
-        test(`
+		test(`
             abc = ""+[0, 1, 2, 3];
             def = [].toString();
             ghi = [null, 4, "null"].toString();
             [ abc, def, ghi ];
         `, "0,1,2,3,,,4,null")
 
-        test(`new Array(0).length`, 0)
+		test(`new Array(0).length`, 0)
 
-        test(`new Array(11).length`, 11)
+		test(`new Array(11).length`, 11)
 
-        test(`new Array(11, 1).length`, 2)
+		test(`new Array(11, 1).length`, 2)
 
-        test(`
+		test(`
             abc = [0, 1, 2, 3];
             abc.xyzzy = "Nothing happens.";
             delete abc[1];
@@ -35,21 +35,21 @@ func TestArray(t *testing.T) {
             [ abc, xyzzy, abc.xyzzy ];
         `, "0,,2,3,true,")
 
-        test(`
+		test(`
             var abc = [0, 1, 2, 3, 4];
             abc.length = 2;
             abc;
         `, "0,1")
 
-        test(`raise:
+		test(`raise:
             [].length = 3.14159;
         `, "RangeError")
 
-        test(`raise:
+		test(`raise:
             new Array(3.14159);
         `, "RangeError")
 
-        test(`
+		test(`
             Object.defineProperty(Array.prototype, "0", {
                 value: 100,
                 writable: false,
@@ -59,23 +59,23 @@ func TestArray(t *testing.T) {
             abc.hasOwnProperty("0") && abc[0] === 101;
         `, true)
 
-        test(`
+		test(`
             abc = [,,undefined];
             [ abc.hasOwnProperty(0), abc.hasOwnProperty(1), abc.hasOwnProperty(2) ];
         `, "false,false,true")
 
-        test(`
+		test(`
             abc = Object.getOwnPropertyDescriptor(Array, "prototype");
             [   [ typeof Array.prototype ],
                 [ abc.writable, abc.enumerable, abc.configurable ] ];
         `, "object,false,false,false")
-    })
+	})
 }
 
 func TestArray_toString(t *testing.T) {
-    tt(t, func() {
-        {
-            test(`
+	tt(t, func() {
+		{
+			test(`
                 Array.prototype.toString = function() {
                     return "Nothing happens.";
                 }
@@ -85,10 +85,10 @@ func TestArray_toString(t *testing.T) {
 
                 [ abc, def, ghi ].join(",");
             `, "Nothing happens.,Nothing happens.,Nothing happens.")
-        }
+		}
 
-        {
-            test(`
+		{
+			test(`
                 Array.prototype.join = undefined
                 abc = Array.prototype.toString()
                 def = [].toString()
@@ -96,33 +96,35 @@ func TestArray_toString(t *testing.T) {
 
                 abc + "," + def + "," + ghi;
             `, "[object Array],[object Array],[object Array]")
-        }
-    })
+		}
+	})
 }
 
 func TestArray_iterator(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             var iterator = [1, 2, 3]["Symbol(Symbol.iterator)"]();
             one = iterator.next().value
             two = iterator.next().value
             three = iterator.next().value
+            end = iterator.next().value
 
-            one + "," + two + "," + three
-        `, "1,2,3")
+            one + "," + two + "," + three + "," + end
+        `, "1,2,3,undefined")
 
-        test(`
+		test(`
             var iterator = [1, 2, 3]["Symbol(Symbol.iterator)"]();
             one = iterator.next().done
             two = iterator.next().done
             three = iterator.next().done
+            end = iterator.next().done
 
-            one + "," + two + "," + three
-        `, "false,false,true")
+            one + "," + two + "," + three + "," + end
+        `, "false,false,false,true")
 
-        test(`
+		test(`
             var iterator = []["Symbol(Symbol.iterator)"]();
             res = iterator.next()
             val = res.value
@@ -130,36 +132,36 @@ func TestArray_iterator(t *testing.T) {
 
             val + "," + done
         `, "undefined,true")
-    })
+	})
 }
 
 func TestArray_toLocaleString(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        defer mockUTC()()
+		defer mockUTC()()
 
-        test(`
+		test(`
             [ 3.14159, "abc", undefined, new Date(0) ].toLocaleString();
         `, "3.14159,abc,,1970-01-01 00:00:00")
 
-        test(`
+		test(`
                 var arr = [ 3.14159, "abc", undefined, new Date(0) ];
                 arr.length = 10;
                 arr.toLocaleString();
             `, "3.14159,abc,,1970-01-01 00:00:00,,,,,,")
 
-        test(`raise:
+		test(`raise:
             [ { toLocaleString: undefined } ].toLocaleString();
         `, "TypeError")
-    })
+	})
 }
 
 func TestArray_concat(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             abc = [0, 1, 2];
             def = [-1, -2, -3];
             ghi = abc.concat(def);
@@ -169,7 +171,7 @@ func TestArray_concat(t *testing.T) {
             [ ghi, jkl, mno ].join(";");
         `, "0,1,2,-1,-2,-3;0,1,2,-1,-2,-3,3,4,5;-1,-2,-3,-4,-5,0,1,2")
 
-        test(`
+		test(`
             var abc = [,1];
             var def = abc.concat([], [,]);
 
@@ -178,7 +180,7 @@ func TestArray_concat(t *testing.T) {
             [ def.getClass(), typeof def[0], def[1], typeof def[2], def.length ];
         `, "[object Array],undefined,1,undefined,3")
 
-        test(`
+		test(`
             Object.defineProperty(Array.prototype, "0", {
                 value: 100,
                 writable: false,
@@ -209,14 +211,14 @@ func TestArray_concat(t *testing.T) {
 
             [ hasProperty, instanceOfVerify, verifyValue, !verifyConfigurable, verifyEnumerable, verifyWritable ];
         `, "true,true,true,true,true,true")
-    })
+	})
 }
 
 func TestArray_splice(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             abc = [0, 1, 2];
             def = abc.splice(1, 2, 3, 4, 5);
             ghi = [].concat(abc);
@@ -225,14 +227,14 @@ func TestArray_splice(t *testing.T) {
             pqr = mno.splice(2);
             [ abc, def, ghi, jkl, mno, pqr ].join(";");
         `, "0,3,4,5;1,2;0,3,4,5,7,8,9;;0,3;4,5")
-    })
+	})
 }
 
 func TestArray_shift(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             abc = [0, 1, 2];
             def = abc.shift();
             ghi = [].concat(abc);
@@ -244,14 +246,14 @@ func TestArray_shift(t *testing.T) {
 
             [ abc, def, ghi, jkl, mno, pqr, stu, vwx ].join(";");
         `, ";0;1,2;1;2;2;;")
-    })
+	})
 }
 
 func TestArray_push(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             abc = [0];
             def = abc.push(1);
             ghi = [].concat(abc);
@@ -259,14 +261,14 @@ func TestArray_push(t *testing.T) {
 
             [ abc, def, ghi, jkl ].join(";");
         `, "0,1,2,3,4;2;0,1;5")
-    })
+	})
 }
 
 func TestArray_pop(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             abc = [0,1];
             def = abc.pop();
             ghi = [].concat(abc);
@@ -276,14 +278,14 @@ func TestArray_pop(t *testing.T) {
 
             [ abc, def, ghi, jkl, mno, pqr ].join(";");
         `, ";1;0;0;;")
-    })
+	})
 }
 
 func TestArray_slice(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             abc = [0,1,2,3];
             def = abc.slice();
             ghi = abc.slice(1);
@@ -296,8 +298,8 @@ func TestArray_slice(t *testing.T) {
             [ abc, def, ghi, jkl, mno, pqr, stu ].join(";");
         `, "0,1,2,3,,,,,,;0,1,2,3;1,2,3;;2;;2,3,,,,,")
 
-        // Array.protoype.slice is generic
-        test(`
+		// Array.protoype.slice is generic
+		test(`
             abc = { 0: 0, 1: 1, 2: 2, 3: 3 };
             abc.length = 4;
             def = Array.prototype.slice.call(abc);
@@ -308,26 +310,26 @@ func TestArray_slice(t *testing.T) {
 
             [ abc, def, ghi, jkl, pqr ].join(";");
         `, "[object Object];0,1,2,3;1,2,3;;")
-    })
+	})
 }
 
 func TestArray_sliceArguments(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             (function(){
                 return Array.prototype.slice.call(arguments, 1)
             })({}, 1, 2, 3);
         `, "1,2,3")
-    })
+	})
 }
 
 func TestArray_unshift(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             abc = [];
             def = abc.unshift(0);
             ghi = [].concat(abc);
@@ -335,27 +337,27 @@ func TestArray_unshift(t *testing.T) {
 
             [ abc, def, ghi, jkl ].join(";");
         `, "1,2,3,4,0;1;0;5")
-    })
+	})
 }
 
 func TestArray_reverse(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             abc = [0,1,2,3].reverse();
             def = [0,1,2].reverse();
 
             [ abc, def ];
         `, "3,2,1,0,2,1,0")
-    })
+	})
 }
 
 func TestArray_sort(t *testing.T) {
-    tt(t, func() {
-        test, vm := test()
+	tt(t, func() {
+		test, vm := test()
 
-        test(`
+		test(`
             abc = [0,1,2,3].sort();
             def = [3,2,1,0].sort();
             ghi = [].sort();
@@ -371,140 +373,140 @@ func TestArray_sort(t *testing.T) {
             [ abc, def, ghi, jkl, mno, pqr, stu, vwx, yza ].join(";");
         `, "0,1,2,3;0,1,2,3;;0;0,1;-10,0.05,1,100,401,5,72,8;-10,0.05,1,5,8,72,100,401;1,1,2,2,3,3;-1,0,0,1,1,1,2,3")
 
-        test(`Array.prototype.sort.length`, 1)
+		test(`Array.prototype.sort.length`, 1)
 
-        // inject quicksort code
-        _, err := vm.Run(jsQuickSort)
-        is(err, nil)
+		// inject quicksort code
+		_, err := vm.Run(jsQuickSort)
+		is(err, nil)
 
-        testSlice := []Value{toValue(5), toValue(3), toValue(2), toValue(4), toValue(1)}
-        vm.Set("testSlice", testSlice)
-        _, err = vm.Run("quickSort(testSlice, 0, testSlice.length-1);")
-        is(err, nil)
+		testSlice := []Value{toValue(5), toValue(3), toValue(2), toValue(4), toValue(1)}
+		vm.Set("testSlice", testSlice)
+		_, err = vm.Run("quickSort(testSlice, 0, testSlice.length-1);")
+		is(err, nil)
 
-        is(test(`testSlice[0]`).export(), 1)
-        is(test(`testSlice[1]`).export(), 2)
-        is(test(`testSlice[2]`).export(), 3)
-        is(test(`testSlice[3]`).export(), 4)
-        is(test(`testSlice[4]`).export(), 5)
+		is(test(`testSlice[0]`).export(), 1)
+		is(test(`testSlice[1]`).export(), 2)
+		is(test(`testSlice[2]`).export(), 3)
+		is(test(`testSlice[3]`).export(), 4)
+		is(test(`testSlice[4]`).export(), 5)
 
-        is(testSlice[0], 1)
-        is(testSlice[1], 2)
-        is(testSlice[2], 3)
-        is(testSlice[3], 4)
-        is(testSlice[4], 5)
-    })
+		is(testSlice[0], 1)
+		is(testSlice[1], 2)
+		is(testSlice[2], 3)
+		is(testSlice[3], 4)
+		is(testSlice[4], 5)
+	})
 }
 
 func TestArray_isArray(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
         [ Array.isArray.length, Array.isArray(), Array.isArray([]), Array.isArray({}) ];
         `, "1,false,true,false")
 
-        test(`Array.isArray(Math)`, false)
-    })
+		test(`Array.isArray(Math)`, false)
+	})
 }
 
 func TestArray_indexOf(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`['a', 'b', 'c', 'b'].indexOf('b')`, 1)
+		test(`['a', 'b', 'c', 'b'].indexOf('b')`, 1)
 
-        test(`['a', 'b', 'c', 'b'].indexOf('b', 2)`, 3)
+		test(`['a', 'b', 'c', 'b'].indexOf('b', 2)`, 3)
 
-        test(`['a', 'b', 'c', 'b'].indexOf('b', -2)`, 3)
+		test(`['a', 'b', 'c', 'b'].indexOf('b', -2)`, 3)
 
-        test(`
+		test(`
             Object.prototype.indexOf = Array.prototype.indexOf;
             var abc = {0: 'a', 1: 'b', 2: 'c', length: 3};
             abc.indexOf('c');
         `, 2)
 
-        test(`[true].indexOf(true, "-Infinity")`, 0)
+		test(`[true].indexOf(true, "-Infinity")`, 0)
 
-        test(`
+		test(`
             var target = {};
             Math[3] = target;
             Math.length = 5;
             Array.prototype.indexOf.call(Math, target) === 3;
         `, true)
 
-        test(`
+		test(`
             var _NaN = NaN;
             var abc = new Array("NaN", undefined, 0, false, null, {toString:function(){return NaN}}, "false", _NaN, NaN);
             abc.indexOf(NaN);
         `, -1)
 
-        test(`
+		test(`
             var abc = {toString:function (){return 0}};
             var def = 1;
             var ghi = -(4/3);
             var jkl = new Array(false, undefined, null, "0", abc, -1.3333333333333, "string", -0, true, +0, def, 1, 0, false, ghi, -(4/3));
             [ jkl.indexOf(-(4/3)), jkl.indexOf(0), jkl.indexOf(-0), jkl.indexOf(1) ];
         `, "14,7,7,10")
-    })
+	})
 }
 
 func TestArray_lastIndexOf(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`['a', 'b', 'c', 'b'].lastIndexOf('b')`, 3)
+		test(`['a', 'b', 'c', 'b'].lastIndexOf('b')`, 3)
 
-        test(`['a', 'b', 'c', 'b'].lastIndexOf('b', 2)`, 1)
+		test(`['a', 'b', 'c', 'b'].lastIndexOf('b', 2)`, 1)
 
-        test(`['a', 'b', 'c', 'b'].lastIndexOf('b', -2)`, 1)
+		test(`['a', 'b', 'c', 'b'].lastIndexOf('b', -2)`, 1)
 
-        test(`
+		test(`
             Object.prototype.lastIndexOf = Array.prototype.lastIndexOf;
             var abc = {0: 'a', 1: 'b', 2: 'c', 3: 'b', length: 4};
             abc.lastIndexOf('b');
         `, 3)
 
-        test(`
+		test(`
             var target = {};
             Math[3] = target;
             Math.length = 5;
             [ Array.prototype.lastIndexOf.call(Math, target) === 3 ];
         `, "true")
 
-        test(`
+		test(`
             var _NaN = NaN;
             var abc = new Array("NaN", undefined, 0, false, null, {toString:function(){return NaN}}, "false", _NaN, NaN);
             abc.lastIndexOf(NaN);
         `, -1)
 
-        test(`
+		test(`
             var abc = {toString:function (){return 0}};
             var def = 1;
             var ghi = -(4/3);
             var jkl = new Array(false, undefined, null, "0", abc, -1.3333333333333, "string", -0, true, +0, def, 1, 0, false, ghi, -(4/3));
             [ jkl.lastIndexOf(-(4/3)), jkl.indexOf(0), jkl.indexOf(-0), jkl.indexOf(1) ];
         `, "15,7,7,10")
-    })
+	})
 }
 
 func TestArray_every(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`raise: [].every()`, "TypeError")
+		test(`raise: [].every()`, "TypeError")
 
-        test(`raise: [].every("abc")`, "TypeError")
+		test(`raise: [].every("abc")`, "TypeError")
 
-        test(`[].every(function() { return false })`, true)
+		test(`[].every(function() { return false })`, true)
 
-        test(`[1,2,3].every(function() { return false })`, false)
+		test(`[1,2,3].every(function() { return false })`, false)
 
-        test(`[1,2,3].every(function() { return true })`, true)
+		test(`[1,2,3].every(function() { return true })`, true)
 
-        test(`[1,2,3].every(function(_, index) { if (index === 1) return true })`, false)
+		test(`[1,2,3].every(function(_, index) { if (index === 1) return true })`, false)
 
-        test(`
+		test(`
             var abc = function(value, index, object) {
                 return ('[object Math]' !== Object.prototype.toString.call(object));
             };
@@ -514,7 +516,7 @@ func TestArray_every(t *testing.T) {
             !Array.prototype.every.call(Math, abc);
         `, true)
 
-        test(`
+		test(`
             var def = false;
 
             var abc = function(value, index, object) {
@@ -525,7 +527,7 @@ func TestArray_every(t *testing.T) {
             [11].every(abc, Math) && def;
         `, true)
 
-        test(`
+		test(`
             var def = false;
 
             var abc = function(value, index, object) {
@@ -535,24 +537,24 @@ func TestArray_every(t *testing.T) {
 
             [11].every(abc) && def;
         `, true)
-    })
+	})
 }
 
 func TestArray_some(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`raise: [].some("abc")`, "TypeError")
+		test(`raise: [].some("abc")`, "TypeError")
 
-        test(`[].some(function() { return true })`, false)
+		test(`[].some(function() { return true })`, false)
 
-        test(`[1,2,3].some(function() { return false })`, false)
+		test(`[1,2,3].some(function() { return false })`, false)
 
-        test(`[1,2,3].some(function() { return true })`, true)
+		test(`[1,2,3].some(function() { return true })`, true)
 
-        test(`[1,2,3].some(function(_, index) { if (index === 1) return true })`, true)
+		test(`[1,2,3].some(function(_, index) { if (index === 1) return true })`, true)
 
-        test(`
+		test(`
             var abc = function(value, index, object) {
                 return ('[object Math]' !== Object.prototype.toString.call(object));
             };
@@ -562,7 +564,7 @@ func TestArray_some(t *testing.T) {
             !Array.prototype.some.call(Math, abc);
         `, true)
 
-        test(`
+		test(`
             var abc = function(value, index, object) {
                 return this === Math;
             };
@@ -570,23 +572,23 @@ func TestArray_some(t *testing.T) {
             [11].some(abc, Math);
         `, true)
 
-        test(`
+		test(`
             var abc = function(value, index, object) {
                 return Math;
             };
 
             [11].some(abc);
         `, true)
-    })
+	})
 }
 
 func TestArray_forEach(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`raise: [].forEach("abc")`, "TypeError")
+		test(`raise: [].forEach("abc")`, "TypeError")
 
-        test(`
+		test(`
             var abc = 0;
             [].forEach(function(value) {
                 abc += value;
@@ -594,7 +596,7 @@ func TestArray_forEach(t *testing.T) {
             abc;
         `, 0)
 
-        test(`
+		test(`
             abc = 0;
             var def = [];
             [1,2,3].forEach(function(value, index) {
@@ -604,7 +606,7 @@ func TestArray_forEach(t *testing.T) {
             [ abc, def ];
         `, "6,0,1,2")
 
-        test(`
+		test(`
             var def = false;
             var abc = function(value, index, object) {
                 def = ('[object Math]' === Object.prototype.toString.call(object));
@@ -616,7 +618,7 @@ func TestArray_forEach(t *testing.T) {
             def;
         `, true)
 
-        test(`
+		test(`
             var def = false;
             var abc = function(value, index, object) {
                 def = this === Math;
@@ -625,14 +627,14 @@ func TestArray_forEach(t *testing.T) {
             [11].forEach(abc, Math);
             def;
         `, true)
-    })
+	})
 }
 
 func TestArray_indexing(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             var abc = new Array(0, 1);
             var def = abc.length;
             abc[4294967296] = 10; // 2^32 => 0
@@ -640,7 +642,7 @@ func TestArray_indexing(t *testing.T) {
             [ def, abc.length, abc[0], abc[1], abc[4294967296] ];
         `, "2,2,0,1,10")
 
-        test(`
+		test(`
             abc = new Array(0, 1);
             def = abc.length;
             abc[4294967295] = 10;
@@ -650,22 +652,22 @@ func TestArray_indexing(t *testing.T) {
             abc[4294967294] = 11;
             [ def, ghi, jkl, abc.length, abc[4294967295], abc[4294967299] ];
         `, "2,2,2,4294967295,10,12")
-    })
+	})
 }
 
 func TestArray_map(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`raise: [].map("abc")`, "TypeError")
+		test(`raise: [].map("abc")`, "TypeError")
 
-        test(`[].map(function() { return 1 }).length`, 0)
+		test(`[].map(function() { return 1 }).length`, 0)
 
-        test(`[1,2,3].map(function(value) { return value * value })`, "1,4,9")
+		test(`[1,2,3].map(function(value) { return value * value })`, "1,4,9")
 
-        test(`[1,2,3].map(function(value) { return 1 })`, "1,1,1")
+		test(`[1,2,3].map(function(value) { return 1 })`, "1,1,1")
 
-        test(`
+		test(`
             var abc = function(value, index, object) {
                 return ('[object Math]' === Object.prototype.toString.call(object));
             };
@@ -675,7 +677,7 @@ func TestArray_map(t *testing.T) {
             Array.prototype.map.call(Math, abc)[0];
         `, true)
 
-        test(`
+		test(`
             var abc = function(value, index, object) {
                 return this === Math;
             };
@@ -683,81 +685,81 @@ func TestArray_map(t *testing.T) {
             [11].map(abc, Math)[0];
         `, true)
 
-        test(`
+		test(`
             var array1 = [1, 4, 9, 16];
             array1.length = 999;
             array1[7] = 25;
             array1.map(function(x) { return x * 2 });
         `, "2,8,18,32,,,,50"+strings.Repeat(",", 999-8))
-    })
+	})
 }
 
 func TestArray_filter(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`raise: [].filter("abc")`, "TypeError")
+		test(`raise: [].filter("abc")`, "TypeError")
 
-        test(`[].filter(function() { return 1 }).length`, 0)
+		test(`[].filter(function() { return 1 }).length`, 0)
 
-        test(`[1,2,3].filter(function() { return false }).length`, 0)
+		test(`[1,2,3].filter(function() { return false }).length`, 0)
 
-        test(`[1,2,3].filter(function() { return true })`, "1,2,3")
+		test(`[1,2,3].filter(function() { return true })`, "1,2,3")
 
-        test(`
+		test(`
             var array1 = [1, 4, 9, 16];
             array1.length = 999;
             array1[7] = 25;
             array1.filter(function(x) { return true });
         `, "1,4,9,16,,,,25"+strings.Repeat(",", 999-8))
-    })
+	})
 }
 
 func TestArray_reduce(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`raise: [].reduce("abc")`, "TypeError")
+		test(`raise: [].reduce("abc")`, "TypeError")
 
-        test(`raise: [].reduce(function() {})`, "TypeError")
+		test(`raise: [].reduce(function() {})`, "TypeError")
 
-        test(`[].reduce(function() {}, 0)`, 0)
+		test(`[].reduce(function() {}, 0)`, 0)
 
-        test(`[].reduce(function() {}, undefined)`, "undefined")
+		test(`[].reduce(function() {}, undefined)`, "undefined")
 
-        test(`['a','b','c'].reduce(function(result, value) { return result+', '+value })`, "a, b, c")
+		test(`['a','b','c'].reduce(function(result, value) { return result+', '+value })`, "a, b, c")
 
-        test(`[1,2,3].reduce(function(result, value) { return result + value }, 4)`, 10)
+		test(`[1,2,3].reduce(function(result, value) { return result + value }, 4)`, 10)
 
-        test(`[1,2,3].reduce(function(result, value) { return result + value })`, 6)
-    })
+		test(`[1,2,3].reduce(function(result, value) { return result + value })`, 6)
+	})
 }
 
 func TestArray_reduceRight(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`raise: [].reduceRight("abc")`, "TypeError")
+		test(`raise: [].reduceRight("abc")`, "TypeError")
 
-        test(`raise: [].reduceRight(function() {})`, "TypeError")
+		test(`raise: [].reduceRight(function() {})`, "TypeError")
 
-        test(`[].reduceRight(function() {}, 0)`, 0)
+		test(`[].reduceRight(function() {}, 0)`, 0)
 
-        test(`[].reduceRight(function() {}, undefined)`, "undefined")
+		test(`[].reduceRight(function() {}, undefined)`, "undefined")
 
-        test(`['a','b','c'].reduceRight(function(result, value) { return result+', '+value })`, "c, b, a")
+		test(`['a','b','c'].reduceRight(function(result, value) { return result+', '+value })`, "c, b, a")
 
-        test(`[1,2,3].reduceRight(function(result, value) { return result + value }, 4)`, 10)
+		test(`[1,2,3].reduceRight(function(result, value) { return result + value }, 4)`, 10)
 
-        test(`[1,2,3].reduceRight(function(result, value) { return result + value })`, 6)
-    })
+		test(`[1,2,3].reduceRight(function(result, value) { return result + value })`, 6)
+	})
 }
 
 func TestArray_defineOwnProperty(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             var abc = [];
             Object.defineProperty(abc, "length", {
                 writable: false
@@ -765,7 +767,7 @@ func TestArray_defineOwnProperty(t *testing.T) {
             abc.length;
         `, 0)
 
-        test(`raise:
+		test(`raise:
             var abc = [];
             var exception;
             Object.defineProperty(abc, "length", {
@@ -775,23 +777,23 @@ func TestArray_defineOwnProperty(t *testing.T) {
                 writable: true
             });
         `, "TypeError")
-    })
+	})
 }
 
 func TestArray_new(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             var abc = new Array(null);
             var def = new Array(undefined);
             [ abc.length, abc[0] === null, def.length, def[0] === undefined ]
         `, "1,true,1,true")
 
-        test(`
+		test(`
             var abc = new Array(new Number(0));
             var def = new Array(new Number(4294967295));
             [ abc.length, typeof abc[0], abc[0] == 0, def.length, typeof def[0], def[0] == 4294967295 ]
         `, "1,object,true,1,object,true")
-    })
+	})
 }

--- a/builtin_array.go
+++ b/builtin_array.go
@@ -626,7 +626,7 @@ func builtinArray_iterator(call FunctionCall) Value {
 		prototype:   call.runtime.global.FunctionPrototype,
 		extensible:  true,
 		property: map[string]_property{
-			"length": _property{
+			"length": {
 				mode: 0,
 				value: Value{
 					kind:  valueNumber,
@@ -651,7 +651,7 @@ func builtinArray_iterator(call FunctionCall) Value {
 		extensible:  true,
 		value:       nil,
 		property: map[string]_property{
-			"next": _property{
+			"next": {
 				mode: 0101,
 				value: Value{
 					kind:  valueObject,
@@ -672,13 +672,15 @@ func builtinArrayIterator_next(list []Value) func(call FunctionCall) Value {
 			return toValue_object(result)
 		}
 
+		if index == len(list) {
+			result.put("done", toValue_bool(true), false)
+			return toValue_object(result)
+		}
+
 		result.put("value", list[index], false)
 		result.put("done", toValue_bool(false), false)
 
 		index++
-		if index == len(list) {
-			result.put("done", toValue_bool(true), false)
-		}
 
 		return toValue_object(result)
 	}

--- a/global_test.go
+++ b/global_test.go
@@ -83,7 +83,7 @@ func TestGlobal(t *testing.T) {
 
 		test(`
             Object.getOwnPropertyNames(Function('return this')()).sort();
-        `, "Array,Boolean,Date,Error,EvalError,Function,Infinity,JSON,Math,NaN,Number,Object,RangeError,ReferenceError,RegExp,String,SyntaxError,TypeError,URIError,console,decodeURI,decodeURIComponent,encodeURI,encodeURIComponent,escape,eval,isFinite,isNaN,parseFloat,parseInt,undefined,unescape")
+        `, "Array,Boolean,Date,Error,EvalError,Function,Infinity,JSON,Math,NaN,Number,Object,RangeError,ReferenceError,RegExp,String,Symbol,SyntaxError,TypeError,URIError,console,decodeURI,decodeURIComponent,encodeURI,encodeURIComponent,escape,eval,isFinite,isNaN,parseFloat,parseInt,undefined,unescape")
 
 		// __defineGetter__,__defineSetter__,__lookupGetter__,__lookupSetter__,constructor,hasOwnProperty,isPrototypeOf,propertyIsEnumerable,toLocaleString,toString,valueOf
 		test(`

--- a/otto_test.go
+++ b/otto_test.go
@@ -1,38 +1,38 @@
 package otto
 
 import (
-    "bytes"
-    "io"
-    "testing"
+	"bytes"
+	"io"
+	"testing"
 
-    "github.com/robertkrimen/otto/parser"
+	"github.com/robertkrimen/otto/parser"
 )
 
 func TestOtto(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test("xyzzy = 2", 2)
+		test("xyzzy = 2", 2)
 
-        test("xyzzy + 2", 4)
+		test("xyzzy + 2", 4)
 
-        test("xyzzy += 16", 18)
+		test("xyzzy += 16", 18)
 
-        test("xyzzy", 18)
+		test("xyzzy", 18)
 
-        test(`
+		test(`
             (function(){
                 return 1
             })()
         `, 1)
 
-        test(`
+		test(`
             (function(){
                 return 1
             }).call(this)
         `, 1)
 
-        test(`
+		test(`
             (function(){
                 var result
                 (function(){
@@ -42,37 +42,37 @@ func TestOtto(t *testing.T) {
             })()
         `, -1)
 
-        test(`
+		test(`
             var abc = 1
             abc || (abc = -1)
             abc
         `, 1)
 
-        test(`
+		test(`
             var abc = (function(){ 1 === 1 })();
             abc;
         `, "undefined")
-    })
+	})
 }
 
 func TestFunction__(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             function abc() {
                 return 1;
             };
             abc();
         `, 1)
-    })
+	})
 }
 
 func TestIf(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             abc = undefined;
             def = undefined;
             if (true) abc = 1
@@ -85,7 +85,7 @@ func TestIf(t *testing.T) {
             [ abc, def ];
         `, "1,4")
 
-        test(`
+		test(`
             if (1) {
                 abc = 1;
             }
@@ -95,7 +95,7 @@ func TestIf(t *testing.T) {
             abc;
         `, 1)
 
-        test(`
+		test(`
             if (0) {
                 abc = 1;
             }
@@ -105,7 +105,7 @@ func TestIf(t *testing.T) {
             abc;
         `, 0)
 
-        test(`
+		test(`
             abc = 0;
             if (0) {
                 abc = 1;
@@ -113,69 +113,69 @@ func TestIf(t *testing.T) {
             abc;
         `, 0)
 
-        test(`
+		test(`
             abc = 0;
             if (abc) {
                 abc = 1;
             }
             abc;
         `, 0)
-    })
+	})
 }
 
 func TestSequence(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             1, 2, 3;
         `, 3)
-    })
+	})
 }
 
 func TestCall(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             Math.pow(3, 2);
         `, 9)
-    })
+	})
 }
 
 func TestRunFunctionWithSetArguments(t *testing.T) {
-    tt(t, func() {
-        vm := New()
-        vm.Run(`var sillyFunction = function(record){record.silly = true; record.answer *= -1};`)
-        record := map[string]interface{}{"foo": "bar", "answer": 42}
-        // Set performs a conversion that allows the map to be addressed as a Javascript object
-        vm.Set("argument", record)
-        _, err := vm.Run("sillyFunction(argument)")
+	tt(t, func() {
+		vm := New()
+		vm.Run(`var sillyFunction = function(record){record.silly = true; record.answer *= -1};`)
+		record := map[string]interface{}{"foo": "bar", "answer": 42}
+		// Set performs a conversion that allows the map to be addressed as a Javascript object
+		vm.Set("argument", record)
+		_, err := vm.Run("sillyFunction(argument)")
 
-        is(err, nil)
-        is(record["answer"].(float64), -42)
-        is(record["silly"].(bool), true)
-    })
+		is(err, nil)
+		is(record["answer"].(float64), -42)
+		is(record["silly"].(bool), true)
+	})
 }
 
 func TestRunFunctionWithArgumentsPassedToCall(t *testing.T) {
-    tt(t, func() {
-        vm := New()
-        vm.Run(`var sillyFunction = function(record){record.silly = true; record.answer *= -1};`)
-        record := map[string]interface{}{"foo": "bar", "answer": 42}
-        _, err := vm.Call("sillyFunction", nil, record)
+	tt(t, func() {
+		vm := New()
+		vm.Run(`var sillyFunction = function(record){record.silly = true; record.answer *= -1};`)
+		record := map[string]interface{}{"foo": "bar", "answer": 42}
+		_, err := vm.Call("sillyFunction", nil, record)
 
-        is(err, nil)
-        is(record["answer"].(float64), -42)
-        is(record["silly"].(bool), true)
-    })
+		is(err, nil)
+		is(record["answer"].(float64), -42)
+		is(record["silly"].(bool), true)
+	})
 }
 
 func TestMember(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             abc = [ 0, 1, 2 ];
             def = {
                 "abc": 0,
@@ -184,24 +184,24 @@ func TestMember(t *testing.T) {
             };
             [ abc[2], def.abc, abc[1], def.def ];
         `, "2,0,1,1")
-    })
+	})
 }
 
 func Test_this(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             typeof this;
         `, "object")
-    })
+	})
 }
 
 func TestWhile(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             limit = 4
             abc = 0
             while (limit) {
@@ -210,14 +210,14 @@ func TestWhile(t *testing.T) {
             }
             abc;
         `, 4)
-    })
+	})
 }
 
 func TestSwitch_break(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             var abc = true;
             var ghi = "Xyzzy";
             while (abc) {
@@ -231,7 +231,7 @@ func TestSwitch_break(t *testing.T) {
             ghi;
         `, "Nothing happens.")
 
-        test(`
+		test(`
             var abc = true;
             var ghi = "Xyzzy";
             WHILE:
@@ -246,7 +246,7 @@ func TestSwitch_break(t *testing.T) {
             ghi;
         `, "Xyzzy")
 
-        test(`
+		test(`
             var ghi = "Xyzzy";
             FOR:
             for (;;) {
@@ -260,7 +260,7 @@ func TestSwitch_break(t *testing.T) {
             ghi;
         `, "Xyzzy")
 
-        test(`
+		test(`
             var ghi = "Xyzzy";
             FOR:
             for (var jkl in {}) {
@@ -274,7 +274,7 @@ func TestSwitch_break(t *testing.T) {
             ghi;
         `, "Xyzzy")
 
-        test(`
+		test(`
             var ghi = "Xyzzy";
             function jkl() {
                 switch ('def') {
@@ -291,14 +291,14 @@ func TestSwitch_break(t *testing.T) {
             }
             ghi;
         `, "Something happens.")
-    })
+	})
 }
 
 func TestTryFinally(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             var abc;
             try {
                 abc = 1;
@@ -309,7 +309,7 @@ func TestTryFinally(t *testing.T) {
             abc;
         `, 2)
 
-        test(`
+		test(`
             var abc = false, def = 0;
             do {
                 def += 1;
@@ -327,7 +327,7 @@ func TestTryFinally(t *testing.T) {
             def;
         `, 1)
 
-        test(`
+		test(`
             var abc = false, def = 0, ghi = 0;
             do {
                 def += 1;
@@ -350,7 +350,7 @@ func TestTryFinally(t *testing.T) {
             ghi;
         `, 11)
 
-        test(`
+		test(`
             var abc = 0, def = 0;
             do {
                 try {
@@ -366,14 +366,14 @@ func TestTryFinally(t *testing.T) {
             while (abc < 2)
             [ abc, def ];
         `, "2,1")
-    })
+	})
 }
 
 func TestTryCatch(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             var abc = 1;
             try {
                 throw 4;
@@ -385,7 +385,7 @@ func TestTryCatch(t *testing.T) {
             abc;
         `, 6)
 
-        test(`
+		test(`
             abc = 1;
             var def;
             try {
@@ -404,14 +404,14 @@ func TestTryCatch(t *testing.T) {
             }
             [ def, abc ];
         `, "64,-2")
-    })
+	})
 }
 
 func TestWith(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             var def;
             with({ abc: 9 }) {
                 def = abc;
@@ -419,7 +419,7 @@ func TestWith(t *testing.T) {
             def;
         `, 9)
 
-        test(`
+		test(`
             var def;
             with({ abc: function(){
                 return 11;
@@ -428,14 +428,14 @@ func TestWith(t *testing.T) {
             }
             def;
         `, 11)
-    })
+	})
 }
 
 func TestSwitch(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             var abc = 0;
             switch (0) {
             default:
@@ -450,7 +450,7 @@ func TestSwitch(t *testing.T) {
             abc;
         `, 15)
 
-        test(`
+		test(`
             abc = 0;
             switch (3) {
             default:
@@ -465,7 +465,7 @@ func TestSwitch(t *testing.T) {
             abc;
         `, 8)
 
-        test(`
+		test(`
             abc = 0;
             switch (60) {
             case 1:
@@ -477,14 +477,14 @@ func TestSwitch(t *testing.T) {
             }
             abc;
         `, 0)
-    })
+	})
 }
 
 func TestForIn(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             var abc;
             for (property in { a: 1 }) {
                 abc = property;
@@ -492,21 +492,21 @@ func TestForIn(t *testing.T) {
             abc;
         `, "a")
 
-        test(`
+		test(`
             var ghi;
             for (property in new String("xyzzy")) {
                 ghi = property;
             }
             ghi;
         `, "4")
-    })
+	})
 }
 
 func TestFor(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             var abc = 7;
             for (i = 0; i < 3; i += 1) {
                 abc += 1;
@@ -514,7 +514,7 @@ func TestFor(t *testing.T) {
             abc;
         `, 10)
 
-        test(`
+		test(`
             abc = 7;
             for (i = 0; i < 3; i += 1) {
                 abc += 1;
@@ -525,7 +525,7 @@ func TestFor(t *testing.T) {
             abc;
         `, 9)
 
-        test(`
+		test(`
             abc = 7;
             for (i = 0; i < 3; i += 1) {
                 if (i == 2) {
@@ -536,7 +536,7 @@ func TestFor(t *testing.T) {
             abc;
         `, 9)
 
-        test(`
+		test(`
             abc = 0;
             for (;;) {
                 abc += 1;
@@ -546,7 +546,7 @@ func TestFor(t *testing.T) {
             abc;
         `, 3)
 
-        test(`
+		test(`
             for (abc = 0; ;) {
                 abc += 1;
                 if (abc == 3)
@@ -555,7 +555,7 @@ func TestFor(t *testing.T) {
             abc;
         `, 3)
 
-        test(`
+		test(`
             for (abc = 0; ; abc += 1) {
                 abc += 1;
                 if (abc == 3)
@@ -563,16 +563,16 @@ func TestFor(t *testing.T) {
             }
             abc;
         `, 3)
-    })
+	})
 }
 
 func TestLabelled(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        // TODO Add emergency break
+		// TODO Add emergency break
 
-        test(`
+		test(`
             xyzzy: for (var abc = 0; abc <= 0; abc++) {
                 for (var def = 0; def <= 1; def++) {
                     if (def === 0) {
@@ -583,7 +583,7 @@ func TestLabelled(t *testing.T) {
             }
         `)
 
-        test(`
+		test(`
             abc = 0
             def:
             while (true) {
@@ -597,7 +597,7 @@ func TestLabelled(t *testing.T) {
             abc;
         `, 12)
 
-        test(`
+		test(`
             abc = 0
             def:
             do {
@@ -610,100 +610,100 @@ func TestLabelled(t *testing.T) {
             } while (true)
             abc;
         `, 12)
-    })
+	})
 }
 
 func TestConditional(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             [ true ? false : true, true ? 1 : 0, false ? 3.14159 : "abc" ];
         `, "false,1,abc")
-    })
+	})
 }
 
 func TestArrayLiteral(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             [ 1, , 3.14159 ];
         `, "1,,3.14159")
-    })
+	})
 }
 
 func TestAssignment(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             var abc = 1;
             abc;
         `, 1)
 
-        test(`
+		test(`
             abc += 2;
             abc;
         `, 3)
-    })
+	})
 }
 
 func TestBinaryOperation(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`0 == 1`, false)
-        test(`1 == "1"`, true)
-        test(`0 === 1`, false)
-        test(`1 === "1"`, false)
-        test(`"1" === "1"`, true)
-    })
+		test(`0 == 1`, false)
+		test(`1 == "1"`, true)
+		test(`0 === 1`, false)
+		test(`1 === "1"`, false)
+		test(`"1" === "1"`, true)
+	})
 }
 
 func Test_typeof(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`typeof abc`, "undefined")
-        test(`typeof abc === 'undefined'`, true)
-        test(`typeof {}`, "object")
-        test(`typeof null`, "object")
-    })
+		test(`typeof abc`, "undefined")
+		test(`typeof abc === 'undefined'`, true)
+		test(`typeof {}`, "object")
+		test(`typeof null`, "object")
+	})
 }
 
 func Test_PrimitiveValueObjectValue(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        Number11 := test(`new Number(11)`)
-        is(Number11.float64(), 11)
-    })
+		Number11 := test(`new Number(11)`)
+		is(Number11.float64(), 11)
+	})
 }
 
 func Test_eval(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        // FIXME terst, Is this correct?
-        test(`
+		// FIXME terst, Is this correct?
+		test(`
             var abc = 1;
         `, "undefined")
 
-        test(`
+		test(`
             eval("abc += 1");
         `, 2)
 
-        test(`
+		test(`
             (function(){
                 var abc = 11;
                 eval("abc += 1");
                 return abc;
             })();
         `, 12)
-        test(`abc`, 2)
+		test(`abc`, 2)
 
-        test(`
+		test(`
             (function(){
                 try {
                     eval("var prop = \\u2029;");
@@ -714,22 +714,22 @@ func Test_eval(t *testing.T) {
             })();
         `, "true,SyntaxError: Unexpected token ILLEGAL")
 
-        test(`
+		test(`
             function abc(){
                 this.THIS = eval("this");
             }
             var def = new abc();
             def === def.THIS;
         `, true)
-    })
+	})
 }
 
 func Test_evalDirectIndirect(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        // (function () {return this;}()).abc = "global";
-        test(`
+		// (function () {return this;}()).abc = "global";
+		test(`
             var abc = "global";
             (function(){
                 try {
@@ -744,16 +744,16 @@ func Test_evalDirectIndirect(t *testing.T) {
                 }
             })();
         `, "true,true")
-    })
+	})
 }
 
 func TestError_URIError(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`new URIError() instanceof URIError`, true)
+		test(`new URIError() instanceof URIError`, true)
 
-        test(`
+		test(`
             var abc
             try {
                 decodeURI("http://example.com/ _^#%")
@@ -763,44 +763,44 @@ func TestError_URIError(t *testing.T) {
             }
             abc
         `, true)
-    })
+	})
 }
 
 func TestTo(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        {
-            value, _ := test(`"11"`).ToFloat()
-            is(value, float64(11))
-        }
+		{
+			value, _ := test(`"11"`).ToFloat()
+			is(value, float64(11))
+		}
 
-        {
-            value, _ := test(`"11"`).ToInteger()
-            is(value, int64(11))
+		{
+			value, _ := test(`"11"`).ToInteger()
+			is(value, int64(11))
 
-            value, _ = test(`1.1`).ToInteger()
-            is(value, int64(1))
-        }
-    })
+			value, _ = test(`1.1`).ToInteger()
+			is(value, int64(1))
+		}
+	})
 }
 
 func TestShouldError(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`raise:
+		test(`raise:
             xyzzy
                 throw new TypeError("Nothing happens.")
         `, "ReferenceError: 'xyzzy' is not defined")
-    })
+	})
 }
 
 func TestAPI(t *testing.T) {
-    tt(t, func() {
-        test, vm := test()
+	tt(t, func() {
+		test, vm := test()
 
-        test(`
+		test(`
             String.prototype.xyzzy = function(){
                 return this.length + 11 + (arguments[0] || 0)
             }
@@ -808,23 +808,23 @@ func TestAPI(t *testing.T) {
             def = "Nothing happens."
             abc.xyzzy()
         `, 16)
-        abc, _ := vm.Get("abc")
-        def, _ := vm.Get("def")
-        object := abc.Object()
-        result, _ := object.Call("xyzzy")
-        is(result, 16)
-        result, _ = object.Call("xyzzy", 1)
-        is(result, 17)
-        value, _ := object.Get("xyzzy")
-        result, _ = value.Call(def)
-        is(result, 27)
-        result, _ = value.Call(def, 3)
-        is(result, 30)
-        object = value.Object() // Object xyzzy
-        result, _ = object.Value().Call(def, 3)
-        is(result, 30)
+		abc, _ := vm.Get("abc")
+		def, _ := vm.Get("def")
+		object := abc.Object()
+		result, _ := object.Call("xyzzy")
+		is(result, 16)
+		result, _ = object.Call("xyzzy", 1)
+		is(result, 17)
+		value, _ := object.Get("xyzzy")
+		result, _ = value.Call(def)
+		is(result, 27)
+		result, _ = value.Call(def, 3)
+		is(result, 30)
+		object = value.Object() // Object xyzzy
+		result, _ = object.Value().Call(def, 3)
+		is(result, 30)
 
-        test(`
+		test(`
             abc = {
                 'abc': 1,
                 'def': false,
@@ -832,105 +832,105 @@ func TestAPI(t *testing.T) {
             };
             abc['abc'];
         `, 1)
-        abc, err := vm.Get("abc")
-        is(err, nil)
-        object = abc.Object() // Object abc
-        value, err = object.Get("abc")
-        is(err, nil)
-        is(value, 1)
-        is(object.Keys(), []string{"abc", "def", "3.14159"})
+		abc, err := vm.Get("abc")
+		is(err, nil)
+		object = abc.Object() // Object abc
+		value, err = object.Get("abc")
+		is(err, nil)
+		is(value, 1)
+		is(object.Keys(), []string{"abc", "def", "3.14159"})
 
-        test(`
+		test(`
             abc = [ 0, 1, 2, 3.14159, "abc", , ];
             abc.def = true;
         `)
-        abc, err = vm.Get("abc")
-        is(err, nil)
-        object = abc.Object() // Object abc
-        is(object.Keys(), []string{"0", "1", "2", "3", "4", "def"})
-    })
+		abc, err = vm.Get("abc")
+		is(err, nil)
+		object = abc.Object() // Object abc
+		is(object.Keys(), []string{"0", "1", "2", "3", "4", "def"})
+	})
 }
 
 func TestObjectKeys(t *testing.T) {
-    tt(t, func() {
-        vm := New()
-        vm.Eval(`var x = Object.create(null); x.a = 1`)
-        vm.Eval(`var y = Object.create(x); y.b = 2`)
+	tt(t, func() {
+		vm := New()
+		vm.Eval(`var x = Object.create(null); x.a = 1`)
+		vm.Eval(`var y = Object.create(x); y.b = 2`)
 
-        o1, _ := vm.Object("x")
-        is(o1.Keys(), []string{"a"})
-        is(o1.KeysByParent(), [][]string{{"a"}})
+		o1, _ := vm.Object("x")
+		is(o1.Keys(), []string{"a"})
+		is(o1.KeysByParent(), [][]string{{"a"}})
 
-        o2, _ := vm.Object("y")
-        is(o2.Keys(), []string{"b"})
-        is(o2.KeysByParent(), [][]string{{"b"}, {"a"}})
-    })
+		o2, _ := vm.Object("y")
+		is(o2.Keys(), []string{"b"})
+		is(o2.KeysByParent(), [][]string{{"b"}, {"a"}})
+	})
 }
 
 func TestUnicode(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`var abc = eval("\"a\uFFFFa\"");`, "undefined")
+		test(`var abc = eval("\"a\uFFFFa\"");`, "undefined")
 
-        test(`abc.length`, 3)
+		test(`abc.length`, 3)
 
-        test(`abc != "aa"`, true)
+		test(`abc != "aa"`, true)
 
-        test("abc[1] === \"\uFFFF\"", true)
-    })
+		test("abc[1] === \"\uFFFF\"", true)
+	})
 }
 
 func TestDotMember(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             abc = {
                 ghi: 11,
             }
             abc.def = "Xyzzy"
             abc.null = "Nothing happens."
         `)
-        test(`abc.def`, "Xyzzy")
-        test(`abc.null`, "Nothing happens.")
-        test(`abc.ghi`, 11)
+		test(`abc.def`, "Xyzzy")
+		test(`abc.null`, "Nothing happens.")
+		test(`abc.ghi`, 11)
 
-        test(`
+		test(`
             abc = {
                 null: 11,
             }
         `)
-        test(`abc.def`, "undefined")
-        test(`abc.null`, 11)
-        test(`abc.ghi`, "undefined")
-    })
+		test(`abc.def`, "undefined")
+		test(`abc.null`, 11)
+		test(`abc.ghi`, "undefined")
+	})
 }
 
 func Test_stringToFloat(t *testing.T) {
-    tt(t, func() {
+	tt(t, func() {
 
-        is(parseNumber("10e10000"), _Infinity)
-        is(parseNumber("10e10_."), _NaN)
-    })
+		is(parseNumber("10e10000"), _Infinity)
+		is(parseNumber("10e10_."), _NaN)
+	})
 }
 
 func Test_delete(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             delete 42;
         `, true)
 
-        test(`
+		test(`
             var abc = delete $_undefined_$;
             abc = abc && delete ($_undefined_$);
             abc;
         `, true)
 
-        // delete should not trigger get()
-        test(`
+		// delete should not trigger get()
+		test(`
             var abc = {
                 get def() {
                     throw "Test_delete: delete should not trigger get()"
@@ -938,14 +938,14 @@ func Test_delete(t *testing.T) {
             };
             delete abc.def
         `, true)
-    })
+	})
 }
 
 func TestObject_defineOwnProperty(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             var object = {};
 
             var descriptor = new Boolean(false);
@@ -962,7 +962,7 @@ func TestObject_defineOwnProperty(t *testing.T) {
             [ abc, def ];
         `, "true,false")
 
-        test(`
+		test(`
             var object = [0, 1, 2];
             Object.defineProperty(object, "0", {
                 value: 42,
@@ -974,35 +974,35 @@ func TestObject_defineOwnProperty(t *testing.T) {
             [ abc.value, abc.writable, abc.enumerable, abc.configurable ];
         `, "42,false,false,false")
 
-        test(`
+		test(`
             var abc = { "xyzzy": 42 };
             var def = Object.defineProperties(abc, "");
             abc === def;
         `, true)
-    })
+	})
 }
 
 func Test_assignmentEvaluationOrder(t *testing.T) {
-    tt(t, func() {
-        test, _ := test()
+	tt(t, func() {
+		test, _ := test()
 
-        test(`
+		test(`
             var abc = 0;
             ((abc = 1) & abc);
         `, 1)
 
-        test(`
+		test(`
             var abc = 0;
             (abc & (abc = 1));
         `, 0)
-    })
+	})
 }
 
 func TestOttoCall(t *testing.T) {
-    tt(t, func() {
-        vm := New()
+	tt(t, func() {
+		vm := New()
 
-        _, err := vm.Run(`
+		_, err := vm.Run(`
             var abc = {
                 ghi: 1,
                 def: function(def){
@@ -1017,83 +1017,83 @@ func TestOttoCall(t *testing.T) {
                 return s.Val;
             }
         `)
-        is(err, nil)
+		is(err, nil)
 
-        value, err := vm.Call(`abc.def`, nil, 2)
-        is(err, nil)
-        is(value, "def: 6.14159")
+		value, err := vm.Call(`abc.def`, nil, 2)
+		is(err, nil)
+		is(value, "def: 6.14159")
 
-        value, err = vm.Call(`abc.def`, "", 2)
-        is(err, nil)
-        is(value, "def: 5.14159")
+		value, err = vm.Call(`abc.def`, "", 2)
+		is(err, nil)
+		is(value, "def: 5.14159")
 
-        // Do not attempt to do a ToValue on a this of nil
-        value, err = vm.Call(`jkl.def`, nil, 1, 2, 3)
-        is(err, "!=", nil)
-        is(value, "undefined")
+		// Do not attempt to do a ToValue on a this of nil
+		value, err = vm.Call(`jkl.def`, nil, 1, 2, 3)
+		is(err, "!=", nil)
+		is(value, "undefined")
 
-        value, err = vm.Call(`[ 1, 2, 3, undefined, 4 ].concat`, nil, 5, 6, 7, "abc")
-        is(err, nil)
-        is(value, "1,2,3,,4,5,6,7,abc")
+		value, err = vm.Call(`[ 1, 2, 3, undefined, 4 ].concat`, nil, 5, 6, 7, "abc")
+		is(err, nil)
+		is(value, "1,2,3,,4,5,6,7,abc")
 
-        s := struct{ Val int }{Val: 10}
-        value, err = vm.Call("structFunc", nil, s)
-        is(err, nil)
-        is(value, 10)
-    })
+		s := struct{ Val int }{Val: 10}
+		value, err = vm.Call("structFunc", nil, s)
+		is(err, nil)
+		is(value, 10)
+	})
 }
 
 func TestOttoCall_new(t *testing.T) {
-    tt(t, func() {
-        test, vm := test()
+	tt(t, func() {
+		test, vm := test()
 
-        vm.Set("abc", func(call FunctionCall) Value {
-            value, err := call.Otto.Call(`new Object`, nil, "Nothing happens.")
-            is(err, nil)
-            return value
-        })
-        test(`
+		vm.Set("abc", func(call FunctionCall) Value {
+			value, err := call.Otto.Call(`new Object`, nil, "Nothing happens.")
+			is(err, nil)
+			return value
+		})
+		test(`
             def = abc();
             [ def, def instanceof String ];
         `, "Nothing happens.,true")
-    })
+	})
 }
 
 func TestOttoCall_newWithBrackets(t *testing.T) {
-    tt(t, func() {
-        test, vm := test()
+	tt(t, func() {
+		test, vm := test()
 
-        _, err := vm.Run(`var a = {default: function B(x) { this.x = x; } }`)
-        is(err, nil)
+		_, err := vm.Run(`var a = {default: function B(x) { this.x = x; } }`)
+		is(err, nil)
 
-        test(`(new a['default'](1)).x`, 1)
-    })
+		test(`(new a['default'](1)).x`, 1)
+	})
 }
 
 func TestOttoCall_throw(t *testing.T) {
-    // FIXME? (Been broken for a while)
-    // Looks like this has been broken for a while... what
-    // behavior do we want here?
+	// FIXME? (Been broken for a while)
+	// Looks like this has been broken for a while... what
+	// behavior do we want here?
 
-    if true {
-        return
-    }
+	if true {
+		return
+	}
 
-    tt(t, func() {
-        test, vm := test()
+	tt(t, func() {
+		test, vm := test()
 
-        vm.Set("abc", func(call FunctionCall) Value {
-            if false {
-                call.Otto.Call(`throw eval`, nil, "({ def: 3.14159 })")
-            }
-            call.Otto.Call(`throw Error`, nil, "abcdef")
-            return Value{}
-        })
-        // TODO try { abc(); } catch (err) { error = err }
-        // Possible unrelated error case:
-        // If error is not declared beforehand, is later referencing it a ReferenceError?
-        // Should the catch { } declare error in the outer scope?
-        test(`
+		vm.Set("abc", func(call FunctionCall) Value {
+			if false {
+				call.Otto.Call(`throw eval`, nil, "({ def: 3.14159 })")
+			}
+			call.Otto.Call(`throw Error`, nil, "abcdef")
+			return Value{}
+		})
+		// TODO try { abc(); } catch (err) { error = err }
+		// Possible unrelated error case:
+		// If error is not declared beforehand, is later referencing it a ReferenceError?
+		// Should the catch { } declare error in the outer scope?
+		test(`
             var error;
             try {
                 abc();
@@ -1104,11 +1104,11 @@ func TestOttoCall_throw(t *testing.T) {
             [ error instanceof Error, error.message, error.def ];
         `, "true,abcdef,")
 
-        vm.Set("def", func(call FunctionCall) Value {
-            call.Otto.Call(`throw new Object`, nil, 3.14159)
-            return UndefinedValue()
-        })
-        test(`
+		vm.Set("def", func(call FunctionCall) Value {
+			call.Otto.Call(`throw new Object`, nil, 3.14159)
+			return UndefinedValue()
+		})
+		test(`
             try {
                 def();
             }
@@ -1117,13 +1117,13 @@ func TestOttoCall_throw(t *testing.T) {
             }
             [ error instanceof Error, error.message, error.def, typeof error, error, error instanceof Number ];
         `, "false,,,object,3.14159,true")
-    })
+	})
 }
 
 func TestOttoCopy(t *testing.T) {
-    tt(t, func() {
-        vm0 := New()
-        vm0.Run(`
+	tt(t, func() {
+		vm0 := New()
+		vm0.Run(`
             var abc = function() {
                 return "Xyzzy";
             };
@@ -1133,39 +1133,39 @@ func TestOttoCopy(t *testing.T) {
             }
         `)
 
-        value, err := vm0.Run(`
+		value, err := vm0.Run(`
             def();
         `)
-        is(err, nil)
-        is(value, "Xyzzy0[object Object]")
+		is(err, nil)
+		is(value, "Xyzzy0[object Object]")
 
-        vm1 := vm0.Copy()
-        value, err = vm1.Run(`
+		vm1 := vm0.Copy()
+		value, err = vm1.Run(`
             def();
         `)
-        is(err, nil)
-        is(value, "Xyzzy0[object Object]")
+		is(err, nil)
+		is(value, "Xyzzy0[object Object]")
 
-        vm1.Run(`
+		vm1.Run(`
             abc = function() {
                 return 3.14159;
             };
         `)
-        value, err = vm1.Run(`
+		value, err = vm1.Run(`
             def();
         `)
-        is(err, nil)
-        is(value, "3.141590[object Object]")
+		is(err, nil)
+		is(value, "3.141590[object Object]")
 
-        value, err = vm0.Run(`
+		value, err = vm0.Run(`
             def();
         `)
-        is(err, nil)
-        is(value, "Xyzzy0[object Object]")
+		is(err, nil)
+		is(value, "Xyzzy0[object Object]")
 
-        {
-            vm0 := New()
-            vm0.Run(`
+		{
+			vm0 := New()
+			vm0.Run(`
                 var global = (function () {return this;}())
                 var abc = 0;
                 var vm = "vm0";
@@ -1184,114 +1184,114 @@ func TestOttoCopy(t *testing.T) {
                 })();
             `)
 
-            value, err := vm0.Run(`
+			value, err := vm0.Run(`
                 def();
             `)
-            is(err, nil)
-            is(value, "vm0,0,0,1")
+			is(err, nil)
+			is(value, "vm0,0,0,1")
 
-            vm1 := vm0.Copy()
-            vm1.Set("vm", "vm1")
-            value, err = vm1.Run(`
+			vm1 := vm0.Copy()
+			vm1.Set("vm", "vm1")
+			value, err = vm1.Run(`
                 def();
             `)
-            is(err, nil)
-            is(value, "vm1,1,1,1")
+			is(err, nil)
+			is(value, "vm1,1,1,1")
 
-            value, err = vm0.Run(`
+			value, err = vm0.Run(`
                 def();
             `)
-            is(err, nil)
-            is(value, "vm0,1,1,1")
+			is(err, nil)
+			is(value, "vm0,1,1,1")
 
-            value, err = vm1.Run(`
+			value, err = vm1.Run(`
                 def();
             `)
-            is(err, nil)
-            is(value, "vm1,2,2,1")
-        }
-    })
+			is(err, nil)
+			is(value, "vm1,2,2,1")
+		}
+	})
 }
 
 func TestOttoCall_clone(t *testing.T) {
-    tt(t, func() {
-        vm := New().clone()
-        rt := vm.runtime
+	tt(t, func() {
+		vm := New().clone()
+		rt := vm.runtime
 
-        {
-            // FIXME terst, Check how this comparison is done
-            is(rt.global.Array.prototype, rt.global.FunctionPrototype)
-            is(rt.global.ArrayPrototype, "!=", nil)
-            is(rt.global.Array.runtime, rt)
-            is(rt.global.Array.prototype, "!=", nil)
-            is(rt.global.Array.prototype.runtime, rt)
-            is(rt.global.Array.get("prototype")._object().runtime, rt)
-        }
+		{
+			// FIXME terst, Check how this comparison is done
+			is(rt.global.Array.prototype, rt.global.FunctionPrototype)
+			is(rt.global.ArrayPrototype, "!=", nil)
+			is(rt.global.Array.runtime, rt)
+			is(rt.global.Array.prototype, "!=", nil)
+			is(rt.global.Array.prototype.runtime, rt)
+			is(rt.global.Array.get("prototype")._object().runtime, rt)
+		}
 
-        {
-            value, err := vm.Run(`[ 1, 2, 3 ].toString()`)
-            is(err, nil)
-            is(value, "1,2,3")
-        }
+		{
+			value, err := vm.Run(`[ 1, 2, 3 ].toString()`)
+			is(err, nil)
+			is(value, "1,2,3")
+		}
 
-        {
-            value, err := vm.Run(`[ 1, 2, 3 ]`)
-            is(err, nil)
-            is(value, "1,2,3")
-            object := value._object()
-            is(object, "!=", nil)
-            is(object.prototype, rt.global.ArrayPrototype)
+		{
+			value, err := vm.Run(`[ 1, 2, 3 ]`)
+			is(err, nil)
+			is(value, "1,2,3")
+			object := value._object()
+			is(object, "!=", nil)
+			is(object.prototype, rt.global.ArrayPrototype)
 
-            value, err = vm.Run(`Array.prototype`)
-            is(err, nil)
-            object = value._object()
-            is(object.runtime, rt)
-            is(object, "!=", nil)
-            is(object, rt.global.ArrayPrototype)
-        }
+			value, err = vm.Run(`Array.prototype`)
+			is(err, nil)
+			object = value._object()
+			is(object.runtime, rt)
+			is(object, "!=", nil)
+			is(object, rt.global.ArrayPrototype)
+		}
 
-        {
-            otto1 := New()
-            _, err := otto1.Run(`
+		{
+			otto1 := New()
+			_, err := otto1.Run(`
                 var abc = 1;
                 var def = 2;
             `)
-            is(err, nil)
+			is(err, nil)
 
-            otto2 := otto1.clone()
-            value, err := otto2.Run(`abc += 1; abc;`)
-            is(err, nil)
-            is(value, 2)
+			otto2 := otto1.clone()
+			value, err := otto2.Run(`abc += 1; abc;`)
+			is(err, nil)
+			is(value, 2)
 
-            value, err = otto1.Run(`abc += 4; abc;`)
-            is(err, nil)
-            is(value, 5)
-        }
+			value, err = otto1.Run(`abc += 4; abc;`)
+			is(err, nil)
+			is(value, 5)
+		}
 
-        {
-            vm1 := New()
-            _, err := vm1.Run(`
+		{
+			vm1 := New()
+			_, err := vm1.Run(`
                 var abc = 1;
                 var def = function(value) {
                     abc += value;
                     return abc;
                 }
             `)
-            is(err, nil)
+			is(err, nil)
 
-            vm2 := vm1.clone()
-            value, err := vm2.Run(`def(1)`)
-            is(err, nil)
-            is(value, 2)
+			vm2 := vm1.clone()
+			value, err := vm2.Run(`def(1)`)
+			is(err, nil)
+			is(value, 2)
 
-            value, err = vm1.Run(`def(4)`)
-            is(err, nil)
-            is(value, 5)
-        }
+			value, err = vm1.Run(`def(4)`)
+			is(err, nil)
+			is(value, 5)
+		}
 
-        {
-            vm1 := New()
-            _, err := vm1.Run(`
+		{
+			vm1 := New()
+			_, err := vm1.Run(`
                 var abc = {
                     ghi: 1,
                     jkl: function(value) {
@@ -1303,158 +1303,158 @@ func TestOttoCall_clone(t *testing.T) {
                     abc: abc
                 };
             `)
-            is(err, nil)
+			is(err, nil)
 
-            otto2 := vm1.clone()
-            value, err := otto2.Run(`def.abc.jkl(1)`)
-            is(err, nil)
-            is(value, 2)
+			otto2 := vm1.clone()
+			value, err := otto2.Run(`def.abc.jkl(1)`)
+			is(err, nil)
+			is(value, 2)
 
-            value, err = vm1.Run(`def.abc.jkl(4)`)
-            is(err, nil)
-            is(value, 5)
-        }
+			value, err = vm1.Run(`def.abc.jkl(4)`)
+			is(err, nil)
+			is(value, 5)
+		}
 
-        {
-            vm1 := New()
-            _, err := vm1.Run(`
+		{
+			vm1 := New()
+			_, err := vm1.Run(`
                 var abc = function() { return "abc"; };
                 var def = function() { return "def"; };
             `)
-            is(err, nil)
+			is(err, nil)
 
-            vm2 := vm1.clone()
-            value, err := vm2.Run(`
+			vm2 := vm1.clone()
+			value, err := vm2.Run(`
                 [ abc.toString(), def.toString() ];
             `)
-            is(value, `function() { return "abc"; },function() { return "def"; }`)
+			is(value, `function() { return "abc"; },function() { return "def"; }`)
 
-            _, err = vm2.Run(`
+			_, err = vm2.Run(`
                 var def = function() { return "ghi"; };
             `)
-            is(err, nil)
+			is(err, nil)
 
-            value, err = vm1.Run(`
+			value, err = vm1.Run(`
                 [ abc.toString(), def.toString() ];
             `)
-            is(value, `function() { return "abc"; },function() { return "def"; }`)
+			is(value, `function() { return "abc"; },function() { return "def"; }`)
 
-            value, err = vm2.Run(`
+			value, err = vm2.Run(`
                 [ abc.toString(), def.toString() ];
             `)
-            is(value, `function() { return "abc"; },function() { return "ghi"; }`)
-        }
+			is(value, `function() { return "abc"; },function() { return "ghi"; }`)
+		}
 
-    })
+	})
 }
 
 func TestOttoRun(t *testing.T) {
-    tt(t, func() {
-        vm := New()
+	tt(t, func() {
+		vm := New()
 
-        program, err := parser.ParseFile(nil, "", "", 0)
-        is(err, nil)
-        value, err := vm.Run(program)
-        is(err, nil)
-        is(value, UndefinedValue())
+		program, err := parser.ParseFile(nil, "", "", 0)
+		is(err, nil)
+		value, err := vm.Run(program)
+		is(err, nil)
+		is(value, UndefinedValue())
 
-        program, err = parser.ParseFile(nil, "", "2 + 2", 0)
-        is(err, nil)
-        value, err = vm.Run(program)
-        is(err, nil)
-        is(value, 4)
-        value, err = vm.Run(program)
-        is(err, nil)
-        is(value, 4)
+		program, err = parser.ParseFile(nil, "", "2 + 2", 0)
+		is(err, nil)
+		value, err = vm.Run(program)
+		is(err, nil)
+		is(value, 4)
+		value, err = vm.Run(program)
+		is(err, nil)
+		is(value, 4)
 
-        program, err = parser.ParseFile(nil, "", "var abc; if (!abc) abc = 0; abc += 2; abc;", 0)
-        value, err = vm.Run(program)
-        is(err, nil)
-        is(value, 2)
-        value, err = vm.Run(program)
-        is(err, nil)
-        is(value, 4)
-        value, err = vm.Run(program)
-        is(err, nil)
-        is(value, 6)
+		program, err = parser.ParseFile(nil, "", "var abc; if (!abc) abc = 0; abc += 2; abc;", 0)
+		value, err = vm.Run(program)
+		is(err, nil)
+		is(value, 2)
+		value, err = vm.Run(program)
+		is(err, nil)
+		is(value, 4)
+		value, err = vm.Run(program)
+		is(err, nil)
+		is(value, 6)
 
-        {
-            src := []byte("var abc; if (!abc) abc = 0; abc += 2; abc;")
-            value, err = vm.Run(src)
-            is(err, nil)
-            is(value, 8)
+		{
+			src := []byte("var abc; if (!abc) abc = 0; abc += 2; abc;")
+			value, err = vm.Run(src)
+			is(err, nil)
+			is(value, 8)
 
-            value, err = vm.Run(bytes.NewBuffer(src))
-            is(err, nil)
-            is(value, 10)
+			value, err = vm.Run(bytes.NewBuffer(src))
+			is(err, nil)
+			is(value, 10)
 
-            value, err = vm.Run(io.Reader(bytes.NewBuffer(src)))
-            is(err, nil)
-            is(value, 12)
-        }
+			value, err = vm.Run(io.Reader(bytes.NewBuffer(src)))
+			is(err, nil)
+			is(value, 12)
+		}
 
-        {
-            script, err := vm.Compile("", `var abc; if (!abc) abc = 0; abc += 2; abc;`)
-            is(err, nil)
+		{
+			script, err := vm.Compile("", `var abc; if (!abc) abc = 0; abc += 2; abc;`)
+			is(err, nil)
 
-            value, err = vm.Run(script)
-            is(err, nil)
-            is(value, 14)
+			value, err = vm.Run(script)
+			is(err, nil)
+			is(value, 14)
 
-            value, err = vm.Run(script)
-            is(err, nil)
-            is(value, 16)
+			value, err = vm.Run(script)
+			is(err, nil)
+			is(value, 16)
 
-            is(script.String(), "// \nvar abc; if (!abc) abc = 0; abc += 2; abc;")
-        }
-    })
+			is(script.String(), "// \nvar abc; if (!abc) abc = 0; abc += 2; abc;")
+		}
+	})
 }
 
 // This generates functions to be used by the test below. The arguments are
 // `src`, which is something that otto can execute, and `expected`, which is
 // what the result of executing `src` should be.
 func makeTestOttoEvalFunction(src, expected interface{}) func(c FunctionCall) Value {
-    return func(c FunctionCall) Value {
-        v, err := c.Otto.Eval(src)
-        is(err, nil)
-        if err != nil {
-            panic(err)
-        }
+	return func(c FunctionCall) Value {
+		v, err := c.Otto.Eval(src)
+		is(err, nil)
+		if err != nil {
+			panic(err)
+		}
 
-        i, err := v.Export()
-        is(err, nil)
-        if err != nil {
-            panic(err)
-        }
+		i, err := v.Export()
+		is(err, nil)
+		if err != nil {
+			panic(err)
+		}
 
-        is(i, expected)
+		is(i, expected)
 
-        return v
-    }
+		return v
+	}
 }
 
 func TestOttoEval(t *testing.T) {
-    tt(t, func() {
-        vm := New()
+	tt(t, func() {
+		vm := New()
 
-        vm.Set("x1", makeTestOttoEvalFunction(`a`, 1))
-        vm.Set("y1", makeTestOttoEvalFunction(`b`, "hello"))
-        vm.Set("z1", makeTestOttoEvalFunction(`c`, true))
-        vm.Set("w", makeTestOttoEvalFunction(`a = 2; b = 'what'; c = false; null`, nil))
-        vm.Set("x2", makeTestOttoEvalFunction(`a`, 2))
-        vm.Set("y2", makeTestOttoEvalFunction(`b`, "what"))
-        vm.Set("z2", makeTestOttoEvalFunction(`c`, false))
+		vm.Set("x1", makeTestOttoEvalFunction(`a`, 1))
+		vm.Set("y1", makeTestOttoEvalFunction(`b`, "hello"))
+		vm.Set("z1", makeTestOttoEvalFunction(`c`, true))
+		vm.Set("w", makeTestOttoEvalFunction(`a = 2; b = 'what'; c = false; null`, nil))
+		vm.Set("x2", makeTestOttoEvalFunction(`a`, 2))
+		vm.Set("y2", makeTestOttoEvalFunction(`b`, "what"))
+		vm.Set("z2", makeTestOttoEvalFunction(`c`, false))
 
-        // note that these variables are defined in the scope of function `t`,
-        // so would not usually be available to the functions called below.
-        //
-        // this is _not_ the recommended use case for `Eval` - instead it's
-        // intended to be used in `debugger` handlers. this code here is the
-        // equivalent of reading behind the current stack frame in C...
-        // technically valid, but completely insane.
-        //
-        // makes for a good test case though.
-        _, err := vm.Run(`(function t() {
+		// note that these variables are defined in the scope of function `t`,
+		// so would not usually be available to the functions called below.
+		//
+		// this is _not_ the recommended use case for `Eval` - instead it's
+		// intended to be used in `debugger` handlers. this code here is the
+		// equivalent of reading behind the current stack frame in C...
+		// technically valid, but completely insane.
+		//
+		// makes for a good test case though.
+		_, err := vm.Run(`(function t() {
             var a = 1;
             var b = 'hello';
             var c = true;
@@ -1468,97 +1468,98 @@ func TestOttoEval(t *testing.T) {
             z2();
         }())`)
 
-        is(err, nil)
-    })
+		is(err, nil)
+	})
 
-    // this test makes sure that `Eval` doesn't explode if the VM doesn't have
-    // a scope other than global defined.
-    tt(t, func() {
-        vm := New()
+	// this test makes sure that `Eval` doesn't explode if the VM doesn't have
+	// a scope other than global defined.
+	tt(t, func() {
+		vm := New()
 
-        _, err := vm.Eval("null")
-        is(err, nil)
+		_, err := vm.Eval("null")
+		is(err, nil)
 
-        vm.Set("a", 1)
-        vm.Set("b", 2)
+		vm.Set("a", 1)
+		vm.Set("b", 2)
 
-        v, err := vm.Eval("a + b")
-        is(err, nil)
-        r, err := v.Export()
-        is(err, nil)
-        is(r, 3)
-    })
+		v, err := vm.Eval("a + b")
+		is(err, nil)
+		r, err := v.Export()
+		is(err, nil)
+		is(r, 3)
+	})
 }
 
 func TestOttoContext(t *testing.T) {
-    // These are all the builtin global scope symbols
-    builtins := []string{
-        "escape",
-        "URIError",
-        "RegExp",
-        "ReferenceError",
-        "parseFloat",
-        "parseInt",
-        "SyntaxError",
-        "decodeURIComponent",
-        "encodeURIComponent",
-        "Infinity",
-        "JSON",
-        "isNaN",
-        "unescape",
-        "decodeURI",
-        "Object",
-        "Function",
-        "RangeError",
-        "Error",
-        "get_context",
-        "eval",
-        "Number",
-        "Math",
-        "NaN",
-        "Date",
-        "Boolean",
-        "console",
-        "encodeURI",
-        "EvalError",
-        "Array",
-        "TypeError",
-        "String",
-        "isFinite",
-        "undefined",
-    }
+	// These are all the builtin global scope symbols
+	builtins := []string{
+		"escape",
+		"URIError",
+		"RegExp",
+		"ReferenceError",
+		"parseFloat",
+		"parseInt",
+		"Symbol",
+		"SyntaxError",
+		"decodeURIComponent",
+		"encodeURIComponent",
+		"Infinity",
+		"JSON",
+		"isNaN",
+		"unescape",
+		"decodeURI",
+		"Object",
+		"Function",
+		"RangeError",
+		"Error",
+		"get_context",
+		"eval",
+		"Number",
+		"Math",
+		"NaN",
+		"Date",
+		"Boolean",
+		"console",
+		"encodeURI",
+		"EvalError",
+		"Array",
+		"TypeError",
+		"String",
+		"isFinite",
+		"undefined",
+	}
 
-    tt(t, func() {
-        vm := New()
+	tt(t, func() {
+		vm := New()
 
-        vm.Set("get_context", func(c FunctionCall) Value {
-            ctx := c.Otto.Context()
-            is(ctx.Callee, "f1")
-            is(ctx.Filename, "<anonymous>")
-            is(ctx.Line, 8)
-            is(ctx.Column, 17)
-            is(ctx.Stacktrace, []string{
-                "f1 (<anonymous>:8:17)",
-                "f2 (<anonymous>:15:17)",
-                "f3 (<anonymous>:19:17)",
-                "t (<anonymous>:22:13)",
-            })
-            is(len(ctx.Symbols), 9+len(builtins))
-            is(ctx.Symbols["a"], 1)
-            is(ctx.Symbols["b"], "hello")
-            is(ctx.Symbols["c"], true)
-            is(ctx.Symbols["j"], 2)
-            is(ctx.Symbols["f1"].IsFunction(), true)
-            is(ctx.Symbols["f2"].IsFunction(), true)
-            is(ctx.Symbols["f3"].IsFunction(), true)
-            is(ctx.Symbols["t"].IsFunction(), true)
-            callee, _ := ctx.Symbols["arguments"].Object().Get("callee")
-            is(callee.IsDefined(), true)
+		vm.Set("get_context", func(c FunctionCall) Value {
+			ctx := c.Otto.Context()
+			is(ctx.Callee, "f1")
+			is(ctx.Filename, "<anonymous>")
+			is(ctx.Line, 8)
+			is(ctx.Column, 17)
+			is(ctx.Stacktrace, []string{
+				"f1 (<anonymous>:8:17)",
+				"f2 (<anonymous>:15:17)",
+				"f3 (<anonymous>:19:17)",
+				"t (<anonymous>:22:13)",
+			})
+			is(len(ctx.Symbols), 9+len(builtins))
+			is(ctx.Symbols["a"], 1)
+			is(ctx.Symbols["b"], "hello")
+			is(ctx.Symbols["c"], true)
+			is(ctx.Symbols["j"], 2)
+			is(ctx.Symbols["f1"].IsFunction(), true)
+			is(ctx.Symbols["f2"].IsFunction(), true)
+			is(ctx.Symbols["f3"].IsFunction(), true)
+			is(ctx.Symbols["t"].IsFunction(), true)
+			callee, _ := ctx.Symbols["arguments"].Object().Get("callee")
+			is(callee.IsDefined(), true)
 
-            return Value{}
-        })
+			return Value{}
+		})
 
-        _, err := vm.Run(`(function t() {
+		_, err := vm.Run(`(function t() {
             var a = 1;
             var b = 'hello';
             var c = true;
@@ -1586,51 +1587,51 @@ func TestOttoContext(t *testing.T) {
             c = false;
         }())`)
 
-        is(err, nil)
-    })
+		is(err, nil)
+	})
 
-    // this test makes sure that `Context` works on global scope by default, if
-    // there is not a current scope.
-    tt(t, func() {
-        vm := New()
+	// this test makes sure that `Context` works on global scope by default, if
+	// there is not a current scope.
+	tt(t, func() {
+		vm := New()
 
-        vm.Set("get_context", func(c FunctionCall) Value {
-            ctx := c.Otto.Context()
-            is(ctx.Callee, "")
-            is(ctx.Filename, "<anonymous>")
-            is(ctx.Line, 3)
-            is(ctx.Column, 13)
-            is(ctx.Stacktrace, []string{"<anonymous>:3:13"})
-            is(len(ctx.Symbols), 2+len(builtins))
-            is(ctx.Symbols["a"], 1)
-            is(ctx.Symbols["b"], UndefinedValue())
+		vm.Set("get_context", func(c FunctionCall) Value {
+			ctx := c.Otto.Context()
+			is(ctx.Callee, "")
+			is(ctx.Filename, "<anonymous>")
+			is(ctx.Line, 3)
+			is(ctx.Column, 13)
+			is(ctx.Stacktrace, []string{"<anonymous>:3:13"})
+			is(len(ctx.Symbols), 2+len(builtins))
+			is(ctx.Symbols["a"], 1)
+			is(ctx.Symbols["b"], UndefinedValue())
 
-            return Value{}
-        })
+			return Value{}
+		})
 
-        _, err := vm.Run(`
+		_, err := vm.Run(`
             var a = 1;
             get_context()
             var b = 2;
         `)
-        is(err, nil)
-    })
+		is(err, nil)
+	})
 
-    // this test makes sure variables are shadowed correctly.
-    tt(t, func() {
-        vm := New()
+	// this test makes sure variables are shadowed correctly.
+	tt(t, func() {
+		vm := New()
 
-        vm.Set("check_context", func(c FunctionCall) Value {
-            n, err := c.Argument(0).ToInteger()
-            is(err, nil)
+		vm.Set("check_context", func(c FunctionCall) Value {
+			n, err := c.Argument(0).ToInteger()
+			is(err, nil)
 
-            ctx := c.Otto.Context()
-            is(ctx.Symbols["a"], n)
+			ctx := c.Otto.Context()
+			is(ctx.Symbols["a"], n)
 
-            return Value{}
-        })
+			return Value{}
+		})
 
-        _, err := vm.Run(`
+		_, err := vm.Run(`
             var a = 1;
             check_context(1);
             (function() {
@@ -1645,33 +1646,33 @@ func TestOttoContext(t *testing.T) {
             }).call(null, 4);
             check_context(1);
         `)
-        is(err, nil)
-    })
+		is(err, nil)
+	})
 }
 
 func Test_objectLength(t *testing.T) {
-    tt(t, func() {
-        _, vm := test()
+	tt(t, func() {
+		_, vm := test()
 
-        value := vm.Set("abc", []string{"jkl", "mno"})
-        is(objectLength(value._object()), 2)
+		value := vm.Set("abc", []string{"jkl", "mno"})
+		is(objectLength(value._object()), 2)
 
-        value, _ = vm.Run(`[1, 2, 3]`)
-        is(objectLength(value._object()), 3)
+		value, _ = vm.Run(`[1, 2, 3]`)
+		is(objectLength(value._object()), 3)
 
-        value, _ = vm.Run(`new String("abcdefghi")`)
-        is(objectLength(value._object()), 9)
+		value, _ = vm.Run(`new String("abcdefghi")`)
+		is(objectLength(value._object()), 9)
 
-        value, _ = vm.Run(`"abcdefghi"`)
-        is(objectLength(value._object()), 0)
-    })
+		value, _ = vm.Run(`"abcdefghi"`)
+		is(objectLength(value._object()), 0)
+	})
 }
 
 func Test_stackLimit(t *testing.T) {
-    // JavaScript stack depth before entering `a` is 5; becomes 6 after
-    // entering. setting the maximum stack depth to 5 should result in an
-    // error ocurring at that 5 -> 6 boundary.
-    code := `
+	// JavaScript stack depth before entering `a` is 5; becomes 6 after
+	// entering. setting the maximum stack depth to 5 should result in an
+	// error ocurring at that 5 -> 6 boundary.
+	code := `
         function a() {}
         function b() { a(); }
         function c() { b(); }
@@ -1680,71 +1681,71 @@ func Test_stackLimit(t *testing.T) {
         e();
     `
 
-    // has no error
-    tt(t, func() {
-        _, vm := test()
+	// has no error
+	tt(t, func() {
+		_, vm := test()
 
-        _, err := vm.Run(code)
+		_, err := vm.Run(code)
 
-        is(err == nil, true)
-    })
+		is(err == nil, true)
+	})
 
-    // has error
-    tt(t, func() {
-        _, vm := test()
+	// has error
+	tt(t, func() {
+		_, vm := test()
 
-        vm.vm.SetStackDepthLimit(2)
+		vm.vm.SetStackDepthLimit(2)
 
-        _, err := vm.Run(code)
+		_, err := vm.Run(code)
 
-        is(err == nil, false)
-    })
+		is(err == nil, false)
+	})
 
-    // has error
-    tt(t, func() {
-        _, vm := test()
+	// has error
+	tt(t, func() {
+		_, vm := test()
 
-        vm.vm.SetStackDepthLimit(5)
+		vm.vm.SetStackDepthLimit(5)
 
-        _, err := vm.Run(code)
+		_, err := vm.Run(code)
 
-        is(err == nil, false)
-    })
+		is(err == nil, false)
+	})
 
-    // has no error
-    tt(t, func() {
-        _, vm := test()
+	// has no error
+	tt(t, func() {
+		_, vm := test()
 
-        vm.vm.SetStackDepthLimit(6)
+		vm.vm.SetStackDepthLimit(6)
 
-        _, err := vm.Run(code)
+		_, err := vm.Run(code)
 
-        is(err == nil, true)
-    })
+		is(err == nil, true)
+	})
 
-    // has no error
-    tt(t, func() {
-        _, vm := test()
+	// has no error
+	tt(t, func() {
+		_, vm := test()
 
-        vm.vm.SetStackDepthLimit(1)
-        vm.vm.SetStackDepthLimit(0)
+		vm.vm.SetStackDepthLimit(1)
+		vm.vm.SetStackDepthLimit(0)
 
-        _, err := vm.Run(code)
+		_, err := vm.Run(code)
 
-        is(err == nil, true)
-    })
+		is(err == nil, true)
+	})
 }
 
 func BenchmarkNew(b *testing.B) {
-    for i := 0; i < b.N; i++ {
-        New()
-    }
+	for i := 0; i < b.N; i++ {
+		New()
+	}
 }
 
 func BenchmarkClone(b *testing.B) {
-    vm := New()
-    b.ResetTimer()
-    for i := 0; i < b.N; i++ {
-        vm.clone()
-    }
+	vm := New()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		vm.clone()
+	}
 }


### PR DESCRIPTION
## ✍️  Description

The issue we were having was with `for ...of` loops so that the following:

```javascript

exports = function(arg){
  const bugsList = context.values.get('valuesBugList');
 
  for (const bug of bugsList) {
    console.log(bug)
  }
};
```

would print every element but the last one. This was due to our implementation not reflecting the specs for iterators.

As we go over the iterable entity, these are the elements returned by the `.next()` method:

```javascript
{ value: "somevalue1", done: false }
{ value: "somevalue2", done: false }
{ value: "somevalue3", done: false }
{ value: "somevalue4", done: true }
```
Since the iterator stops as soon as an element has `done === true` we would skip the last element.

The correct behavior for `.next()` will produce:

```javascript
{ value: "somevalue1", done: false }
{ value: "somevalue2", done: false }
{ value: "somevalue3", done: false }
{ value: "somevalue4", done: false }
{ done: true }
```