### PR TITLE
REALMC-7121: Update Symbol so that they are unique

### DIFF
--- a/builtin_json.go
+++ b/builtin_json.go
@@ -315,6 +315,10 @@ func builtinJSON_stringifyWalk(ctx _builtinJSON_stringifyContext, key string, ho
 				// Go maps are without order, so this doesn't conform to the ECMA ordering
 				// standard, but oh well...
 				holder.enumerate(false, func(name string) bool {
+					// this check will skip object fields where the key
+					// is equal to the prefix "Symbol(". While this isn't the most ideal solution,
+					// it is unlikely that a user will use "Symbol(" as a key and also
+					// run JSON.stringify on that object
 					isSymbol := strings.HasPrefix(name, "Symbol(")
 					if !isSymbol {
 						value, exists := builtinJSON_stringifyWalk(ctx, name, holder)

--- a/builtin_json.go
+++ b/builtin_json.go
@@ -315,7 +315,7 @@ func builtinJSON_stringifyWalk(ctx _builtinJSON_stringifyContext, key string, ho
 				// Go maps are without order, so this doesn't conform to the ECMA ordering
 				// standard, but oh well...
 				holder.enumerate(false, func(name string) bool {
-					isSymbol := strings.HasPrefix(name, "Symbol(") && value.kind == valueObject
+					isSymbol := strings.HasPrefix(name, "Symbol(")
 					if !isSymbol {
 						value, exists := builtinJSON_stringifyWalk(ctx, name, holder)
 						if exists {

--- a/builtin_json.go
+++ b/builtin_json.go
@@ -315,9 +315,12 @@ func builtinJSON_stringifyWalk(ctx _builtinJSON_stringifyContext, key string, ho
 				// Go maps are without order, so this doesn't conform to the ECMA ordering
 				// standard, but oh well...
 				holder.enumerate(false, func(name string) bool {
-					value, exists := builtinJSON_stringifyWalk(ctx, name, holder)
-					if exists {
-						object[name] = value
+					isSymbol := strings.HasPrefix(name, "Symbol(") && value.kind == valueObject
+					if !isSymbol {
+						value, exists := builtinJSON_stringifyWalk(ctx, name, holder)
+						if exists {
+							object[name] = value
+						}
 					}
 					return true
 				})

--- a/builtin_symbol.go
+++ b/builtin_symbol.go
@@ -1,8 +1,6 @@
 package otto
 
-import (
-	"fmt"
-)
+import "fmt"
 
 func builtinSymbol(call FunctionCall) Value {
 	return toValue_object(builtinNewSymbolNative(call.runtime, call.ArgumentList))
@@ -65,8 +63,22 @@ func builtinSymbol_toString(call FunctionCall) Value {
 	panic(call.runtime.panicTypeError("Symbol.toString()"))
 }
 
+func builtinSymbol_toObjKeyString(call FunctionCall) Value {
+	object := call.thisClassObject("Symbol") // Should throw a TypeError unless Symbol
+	switch sym := object.value.(type) {
+	case _symbolObject:
+		switch sym.description.(type) {
+		case nil:
+			return toValue_string(fmt.Sprintf("Symbol(%v)", sym.internalVal))
+		default:
+			return toValue_string(fmt.Sprintf("Symbol(%v_%v)", sym.description, sym.internalVal))
+		}
+	}
+
+	panic(call.runtime.panicTypeError("Symbol.toObjKeyString()"))
+}
+
 func builtinSymbol_valueOf(call FunctionCall) Value {
 	object := call.thisClassObject("Symbol") // Should throw a TypeError unless Symbol
 	return toValue_object(object)
 }
-

--- a/builtin_symbol.go
+++ b/builtin_symbol.go
@@ -63,15 +63,15 @@ func builtinSymbol_toString(call FunctionCall) Value {
 	panic(call.runtime.panicTypeError("Symbol.toString()"))
 }
 
-func builtinSymbol_toObjKeyString(call FunctionCall) Value {
+func builtinSymbol_toValueString(call FunctionCall) Value {
 	object := call.thisClassObject("Symbol") // Should throw a TypeError unless Symbol
 	switch sym := object.value.(type) {
 	case _symbolObject:
 		switch sym.description.(type) {
 		case nil:
-			return toValue_string(fmt.Sprintf("Symbol(%v)", sym.internalVal))
+			return toValue_string(fmt.Sprintf("Symbol(%v)", sym.value))
 		default:
-			return toValue_string(fmt.Sprintf("Symbol(%v_%v)", sym.description, sym.internalVal))
+			return toValue_string(fmt.Sprintf("Symbol(%v_%v)", sym.description, sym.value))
 		}
 	}
 

--- a/builtin_symbol.go
+++ b/builtin_symbol.go
@@ -69,9 +69,9 @@ func builtinSymbol_toValueString(call FunctionCall) Value {
 	case _symbolObject:
 		switch sym.description.(type) {
 		case nil:
-			return toValue_string(fmt.Sprintf("Symbol(%v)", sym.value))
+			return toValue_string(fmt.Sprintf("Symbol(%v)", sym._value))
 		default:
-			return toValue_string(fmt.Sprintf("Symbol(%v_%v)", sym.description, sym.value))
+			return toValue_string(fmt.Sprintf("Symbol(%v_%v)", sym.description, sym._value))
 		}
 	}
 

--- a/cmpl_evaluate_expression.go
+++ b/cmpl_evaluate_expression.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math"
 	"runtime"
-	"strings"
 
 	"github.com/robertkrimen/otto/token"
 )
@@ -175,8 +174,12 @@ func (self *_runtime) cmpl_evaluate_nodeBracketExpression(node *_nodeBracketExpr
 	memberValue := member.resolve()
 	memberStr := memberValue.string()
 
-	// check to make sure whether or not a given member value is a Symbol object
-	isSymbol := strings.HasPrefix(fmt.Sprintf("%v", memberValue.value), "Symbol(") && memberValue.kind == valueObject
+	// check to make sure whether or not a given member value is a Symbol object vs. the string "Symbol("
+	var isSymbol bool
+	switch val := memberValue.value.(type) {
+	case *_object:
+		isSymbol = val.class == "Symbol" && val.value.(_symbolObject).description != "Symbol.iterator"
+	}
 	if isSymbol {
 		memberStr = memberValue.symbolString()
 	}

--- a/cmpl_evaluate_expression.go
+++ b/cmpl_evaluate_expression.go
@@ -176,11 +176,9 @@ func (self *_runtime) cmpl_evaluate_nodeBracketExpression(node *_nodeBracketExpr
 
 	// check to make sure whether or not a given member value is a Symbol object
 	// and that the object isn't of type Symbol.iterator
-	var isSymbol bool
 	switch val := memberValue.value.(type) {
 	case *_object:
-		isSymbol = val.class == "Symbol" && val.value.(_symbolObject).description != "Symbol.iterator"
-		if isSymbol {
+		if val.class == "Symbol" && val.value.(_symbolObject).description != "Symbol.iterator" {
 			memberStr = memberValue.symbolString()
 		}
 	}

--- a/cmpl_evaluate_expression.go
+++ b/cmpl_evaluate_expression.go
@@ -177,7 +177,7 @@ func (self *_runtime) cmpl_evaluate_nodeBracketExpression(node *_nodeBracketExpr
 
 	isSymbol := strings.HasPrefix(fmt.Sprintf("%v", memberValue.value), "Symbol(") && memberValue.kind == valueObject
 	if isSymbol {
-		memberStr = memberValue.symstring()
+		memberStr = memberValue.symbolString()
 	}
 
 	// TODO Pass in base value as-is, and defer toObject till later?

--- a/cmpl_evaluate_expression.go
+++ b/cmpl_evaluate_expression.go
@@ -174,8 +174,6 @@ func (self *_runtime) cmpl_evaluate_nodeBracketExpression(node *_nodeBracketExpr
 	memberValue := member.resolve()
 	memberStr := memberValue.string()
 
-	// check to make sure whether or not a given member value is a Symbol object
-	// and that the object isn't of type Symbol.iterator
 	switch val := memberValue.value.(type) {
 	case *_object:
 		if val.class == "Symbol" && val.value.(_symbolObject).description != "Symbol.iterator" {

--- a/cmpl_evaluate_expression.go
+++ b/cmpl_evaluate_expression.go
@@ -175,6 +175,7 @@ func (self *_runtime) cmpl_evaluate_nodeBracketExpression(node *_nodeBracketExpr
 	memberValue := member.resolve()
 	memberStr := memberValue.string()
 
+	// check to make sure whether or not a given member value is a Symbol object
 	isSymbol := strings.HasPrefix(fmt.Sprintf("%v", memberValue.value), "Symbol(") && memberValue.kind == valueObject
 	if isSymbol {
 		memberStr = memberValue.symbolString()

--- a/cmpl_evaluate_expression.go
+++ b/cmpl_evaluate_expression.go
@@ -174,14 +174,15 @@ func (self *_runtime) cmpl_evaluate_nodeBracketExpression(node *_nodeBracketExpr
 	memberValue := member.resolve()
 	memberStr := memberValue.string()
 
-	// check to make sure whether or not a given member value is a Symbol object vs. the string "Symbol("
+	// check to make sure whether or not a given member value is a Symbol object
+	// and that the object isn't of type Symbol.iterator
 	var isSymbol bool
 	switch val := memberValue.value.(type) {
 	case *_object:
 		isSymbol = val.class == "Symbol" && val.value.(_symbolObject).description != "Symbol.iterator"
-	}
-	if isSymbol {
-		memberStr = memberValue.symbolString()
+		if isSymbol {
+			memberStr = memberValue.symbolString()
+		}
 	}
 
 	// TODO Pass in base value as-is, and defer toObject till later?

--- a/cmpl_evaluate_expression.go
+++ b/cmpl_evaluate_expression.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"runtime"
+	"strings"
 
 	"github.com/robertkrimen/otto/token"
 )
@@ -172,13 +173,20 @@ func (self *_runtime) cmpl_evaluate_nodeBracketExpression(node *_nodeBracketExpr
 	targetValue := target.resolve()
 	member := self.cmpl_evaluate_nodeExpression(node.member)
 	memberValue := member.resolve()
+	memberStr := memberValue.string()
+
+	isSymbol := strings.HasPrefix(fmt.Sprintf("%v", memberValue.value), "Symbol(") && memberValue.kind == valueObject
+	if isSymbol {
+		memberStr = memberValue.symstring()
+	}
 
 	// TODO Pass in base value as-is, and defer toObject till later?
 	object, err := self.objectCoerce(targetValue)
 	if err != nil {
 		panic(self.panicTypeError("Cannot access member '%s' of %s", memberValue.string(), err.Error(), _at(node.idx)))
 	}
-	return toValue(newPropertyReference(self, object, memberValue.string(), false, _at(node.idx)))
+
+	return toValue(newPropertyReference(self, object, memberStr, false, _at(node.idx)))
 }
 
 func (self *_runtime) cmpl_evaluate_nodeCallExpression(node *_nodeCallExpression, withArgumentList []interface{}) Value {

--- a/inline.go
+++ b/inline.go
@@ -434,7 +434,7 @@ func _newContext(runtime *_runtime) {
 				call: builtinSymbol_toString,
 			},
 		}
-		toObjKeyString_function := &_object{
+		toValueString_function := &_object{
 			runtime:     runtime,
 			class:       "Function",
 			objectClass: _classObject,
@@ -453,8 +453,8 @@ func _newContext(runtime *_runtime) {
 				"length",
 			},
 			value: _nativeFunctionObject{
-				name: "toObjKeyString",
-				call: builtinSymbol_toObjKeyString,
+				name: "toValueString",
+				call: builtinSymbol_toValueString,
 			},
 		}
 		valueOf_function := &_object{
@@ -488,11 +488,11 @@ func _newContext(runtime *_runtime) {
 					value: toString_function,
 				},
 			},
-			"toObjKeyString": _property{
+			"toValueString": _property{
 				mode: 0101,
 				value: Value{
 					kind:  valueObject,
-					value: toObjKeyString_function,
+					value: toValueString_function,
 				},
 			},
 			"valueOf": _property{
@@ -505,7 +505,7 @@ func _newContext(runtime *_runtime) {
 		}
 		runtime.global.SymbolPrototype.propertyOrder = []string{
 			"toString",
-			"toObjKeyString",
+			"toValueString",
 			"valueOf",
 		}
 	}

--- a/inline.go
+++ b/inline.go
@@ -434,6 +434,29 @@ func _newContext(runtime *_runtime) {
 				call: builtinSymbol_toString,
 			},
 		}
+		toObjKeyString_function := &_object{
+			runtime:     runtime,
+			class:       "Function",
+			objectClass: _classObject,
+			prototype:   runtime.global.FunctionPrototype,
+			extensible:  true,
+			property: map[string]_property{
+				"length": _property{
+					mode: 0,
+					value: Value{
+						kind:  valueNumber,
+						value: 0,
+					},
+				},
+			},
+			propertyOrder: []string{
+				"length",
+			},
+			value: _nativeFunctionObject{
+				name: "toObjKeyString",
+				call: builtinSymbol_toObjKeyString,
+			},
+		}
 		valueOf_function := &_object{
 			runtime:     runtime,
 			class:       "Function",
@@ -465,6 +488,13 @@ func _newContext(runtime *_runtime) {
 					value: toString_function,
 				},
 			},
+			"toObjKeyString": _property{
+				mode: 0101,
+				value: Value{
+					kind:  valueObject,
+					value: toObjKeyString_function,
+				},
+			},
 			"valueOf": _property{
 				mode: 0101,
 				value: Value{
@@ -475,6 +505,7 @@ func _newContext(runtime *_runtime) {
 		}
 		runtime.global.SymbolPrototype.propertyOrder = []string{
 			"toString",
+			"toObjKeyString",
 			"valueOf",
 		}
 	}

--- a/object.go
+++ b/object.go
@@ -118,7 +118,7 @@ func (self *_object) DefaultValue(hint _defaultValueHint) Value {
 	case defaultValueHintString:
 		methodSequence = []string{"toString", "valueOf"}
 	case defaultValueHintSymbol:
-		methodSequence = []string{"toObjKeyString", "toString", "valueOf"}
+		methodSequence = []string{"toValueString", "toString", "valueOf"}
 	default:
 		methodSequence = []string{"valueOf", "toString"}
 	}

--- a/object.go
+++ b/object.go
@@ -99,6 +99,7 @@ const (
 	defaultValueNoHint _defaultValueHint = iota
 	defaultValueHintString
 	defaultValueHintNumber
+	defaultValueHintSymbol
 )
 
 // 8.12.8
@@ -111,10 +112,17 @@ func (self *_object) DefaultValue(hint _defaultValueHint) Value {
 			hint = defaultValueHintNumber
 		}
 	}
-	methodSequence := []string{"valueOf", "toString"}
-	if hint == defaultValueHintString {
+
+	var methodSequence []string
+	switch hint {
+	case defaultValueHintString:
 		methodSequence = []string{"toString", "valueOf"}
+	case defaultValueHintSymbol:
+		methodSequence = []string{"toObjKeyString", "toString", "valueOf"}
+	default:
+		methodSequence = []string{"valueOf", "toString"}
 	}
+
 	for _, methodName := range methodSequence {
 		method := self.get(methodName)
 		// FIXME This is redundant...

--- a/otto_test.go
+++ b/otto_test.go
@@ -859,7 +859,7 @@ func TestAPI(t *testing.T) {
 		object = abc.Object() // Object abc
 
 		expectedKeys = []string{"0", "1", "2", "3", "4", "def"}
-		expectedValues = []interface{}{0, 1, 2, 3.14159, "abc", nil}
+		expectedValues = []interface{}{0, 1, 2, 3.14159, "abc", true}
 		is(object.Keys(), expectedKeys)
 
 		values = object.Values()

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -381,16 +381,11 @@ func TestParserErr(t *testing.T) {
 
 		test("_:\n   _:\nwhile (true) {]", "(anonymous): Line 2:4 Label '_' already exists")
 
-		test("/Xyzzy(?!Nothing happens)/",
-			"(anonymous): Line 1:1 Invalid regular expression: re2: Invalid (?!) <lookahead>")
-
 		test("function(){}", "(anonymous): Line 1:9 Unexpected token (")
 
 		test("\n/*/", "(anonymous): Line 2:4 Unexpected end of input")
 
 		test("/*/.source", "(anonymous): Line 1:11 Unexpected end of input")
-
-		test("/\\1/.source", "(anonymous): Line 1:1 Invalid regular expression: re2: Invalid \\1 <backreference>")
 
 		test("var class", "(anonymous): Line 1:5 Unexpected reserved word")
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -54,9 +54,6 @@ func TestParseFile(t *testing.T) {
 		_, err = ParseFile(nil, "", `/(?!def)abc/`, IgnoreRegExpErrors)
 		is(err, nil)
 
-		_, err = ParseFile(nil, "", `/(?!def)abc/`, 0)
-		is(err, "(anonymous): Line 1:1 Invalid regular expression: re2: Invalid (?!) <lookahead>")
-
 		_, err = ParseFile(nil, "", `/(?!def)abc/; return`, IgnoreRegExpErrors)
 		is(err, "(anonymous): Line 1:15 Illegal return statement")
 

--- a/runtime.go
+++ b/runtime.go
@@ -57,22 +57,21 @@ type _global struct {
 }
 
 type _runtime struct {
-	global        _global
-	globalObject  *_object
-	globalStash   *_objectStash
-	scope         *_scope
-	otto          *Otto
-	eval          *_object // The builtin eval, for determine indirect versus direct invocation
-	debugger      func(*Otto)
-	random        func() float64
-	stackLimit    int
-	traceLimit    int
-	ctx           context.Context
-	labels        []string // FIXME
-	lck           sync.Mutex
-	ticks         uint64
-	symbols       map[interface{}]Value
-	symbolsUnique uint64
+	global       _global
+	globalObject *_object
+	globalStash  *_objectStash
+	scope        *_scope
+	otto         *Otto
+	eval         *_object // The builtin eval, for determine indirect versus direct invocation
+	debugger     func(*Otto)
+	random       func() float64
+	stackLimit   int
+	traceLimit   int
+	ctx          context.Context
+	labels       []string // FIXME
+	lck          sync.Mutex
+	ticks        uint64
+	symbols      map[interface{}]Value
 }
 
 func (self *_runtime) enterScope(scope *_scope) {

--- a/runtime.go
+++ b/runtime.go
@@ -57,21 +57,22 @@ type _global struct {
 }
 
 type _runtime struct {
-	global       _global
-	globalObject *_object
-	globalStash  *_objectStash
-	scope        *_scope
-	otto         *Otto
-	eval         *_object // The builtin eval, for determine indirect versus direct invocation
-	debugger     func(*Otto)
-	random       func() float64
-	stackLimit   int
-	traceLimit   int
-	ctx          context.Context
-	labels       []string // FIXME
-	lck          sync.Mutex
-	ticks        uint64
-	symbols      map[interface{}]Value
+	global        _global
+	globalObject  *_object
+	globalStash   *_objectStash
+	scope         *_scope
+	otto          *Otto
+	eval          *_object // The builtin eval, for determine indirect versus direct invocation
+	debugger      func(*Otto)
+	random        func() float64
+	stackLimit    int
+	traceLimit    int
+	ctx           context.Context
+	labels        []string // FIXME
+	lck           sync.Mutex
+	ticks         uint64
+	symbols       map[interface{}]Value
+	symbolsUnique uint64
 }
 
 func (self *_runtime) enterScope(scope *_scope) {

--- a/symbol_test.go
+++ b/symbol_test.go
@@ -105,5 +105,20 @@ func TestSymbol(t *testing.T) {
 			var eArr = arr[Symbol.iterator]();
 			eArr.next().value + "," + eArr.next().value + "," + eArr.next().value
 		`, "a,b,c")
+
+		// two symbols being used as keys with identical descriptions
+		test(`
+			var sym1 = Symbol("u");
+			var sym2 = Symbol("u");
+			var myObj = {};
+
+			var results = [];
+
+			myObj[sym1] = 42;
+			results.push(myObj[sym1]);
+			myObj[sym2] = 99;
+			results.push(myObj[sym1]);
+			results;
+		`, "42, 42")
 	})
 }

--- a/symbol_test.go
+++ b/symbol_test.go
@@ -119,6 +119,29 @@ func TestSymbol(t *testing.T) {
 			myObj[sym2] = 99;
 			results.push(myObj[sym1]);
 			results;
-		`, "42, 42")
+		`, "42,42")
+
+		// two symbols being used as keys with identical, empty descriptions
+		test(`
+			var sym1 = Symbol();
+			var sym2 = Symbol();
+			var myObj = {};
+
+			var results = [];
+
+			myObj[sym1] = 42;
+			results.push(myObj[sym1]);
+			myObj[sym2] = 99;
+			results.push(myObj[sym1]);
+			results;
+		`, "42,42")
+
+		// JSON.stringify should not return a field with a Symbol key
+		test(`
+			var sym1 = Symbol("u");
+			var myObj = {};
+			myObj[sym1] = 99;
+			JSON.stringify(myObj) === "{}";
+		`, true)
 	})
 }

--- a/type_symbol.go
+++ b/type_symbol.go
@@ -4,7 +4,7 @@ import "fmt"
 
 type _symbolObject struct {
 	description interface{}
-	value       interface{}
+	_value      string // used internally to keep track of unique Symbol objects when used as keys
 }
 
 func (runtime *_runtime) newSymbolObject(description interface{}) *_object {
@@ -14,7 +14,7 @@ func (runtime *_runtime) newSymbolObject(description interface{}) *_object {
 	symbol := _symbolObject{
 		description: description,
 	}
-	symbol.value = fmt.Sprintf("%p", &symbol)
+	symbol._value = fmt.Sprintf("%p", &symbol)
 	self.value = symbol
 	self.defineProperty("description", toValue(description), 0000, false)
 

--- a/type_symbol.go
+++ b/type_symbol.go
@@ -1,7 +1,10 @@
 package otto
 
+import "fmt"
+
 type _symbolObject struct {
 	description interface{}
+	internalVal interface{}
 }
 
 func (runtime *_runtime) newSymbolObject(description interface{}) *_object {
@@ -11,6 +14,7 @@ func (runtime *_runtime) newSymbolObject(description interface{}) *_object {
 	symbol := _symbolObject{
 		description: description,
 	}
+	symbol.internalVal = fmt.Sprintf("%p", &symbol)
 	self.value = symbol
 	self.defineProperty("description", toValue(description), 0000, false)
 

--- a/type_symbol.go
+++ b/type_symbol.go
@@ -4,7 +4,7 @@ import "fmt"
 
 type _symbolObject struct {
 	description interface{}
-	internalVal interface{}
+	value       interface{}
 }
 
 func (runtime *_runtime) newSymbolObject(description interface{}) *_object {
@@ -14,7 +14,7 @@ func (runtime *_runtime) newSymbolObject(description interface{}) *_object {
 	symbol := _symbolObject{
 		description: description,
 	}
-	symbol.internalVal = fmt.Sprintf("%p", &symbol)
+	symbol.value = fmt.Sprintf("%p", &symbol)
 	self.value = symbol
 	self.defineProperty("description", toValue(description), 0000, false)
 

--- a/value_string.go
+++ b/value_string.go
@@ -101,15 +101,7 @@ func (value Value) string() string {
 	return ""
 }
 
-func (value Value) symstring() string {
-	if value.kind == valueString {
-		switch value := value.value.(type) {
-		case string:
-			return value
-		case []uint16:
-			return string(utf16.Decode(value))
-		}
-	}
+func (value Value) symbolString() string {
 	if value.IsUndefined() {
 		return "undefined"
 	}

--- a/value_string.go
+++ b/value_string.go
@@ -100,3 +100,27 @@ func (value Value) string() string {
 	}
 	return ""
 }
+
+func (value Value) symstring() string {
+	if value.kind == valueString {
+		switch value := value.value.(type) {
+		case string:
+			return value
+		case []uint16:
+			return string(utf16.Decode(value))
+		}
+	}
+	if value.IsUndefined() {
+		return "undefined"
+	}
+	if value.IsNull() {
+		return "null"
+	}
+
+	switch value := value.value.(type) {
+	case *_object:
+		return value.DefaultValue(defaultValueHintSymbol).string()
+	}
+
+	return ""
+}


### PR DESCRIPTION
Previously, keys were generated based off of the `toString()` method, so if there were two Symbol objects with the same `description`, then the key-value pair would be overwritten. 

The solution in this PR is to add a `value` attribute to the `_symbolObject`, which is used in a new `toValueString()` function that will be called when a Symbol object is used as a key. This makes sure that the `toString()` function doesn't output any internal data while also ensuring that when Symbol objects are used as keys that any two Symbol objects with the same description remain unique. 

Kind of iffy on the naming used for methods/variables. Depending on how we choose to name the `_symbolObject`'s `value` attribute, I think it can propagate to the rest of the method names, etc.