### PR TITLE
REALMC-7122: add support for Array.Prototype.entries

### DIFF
--- a/array_test.go
+++ b/array_test.go
@@ -109,7 +109,16 @@ func TestArray_iterator(t *testing.T) {
             var iterator = a.entries();
 
             iterator.next().value + " " + iterator.next().value + " " + iterator.next().value
-		`, "0,a 1,b 2,c")
+        `, "0,a 1,b 2,c")
+
+		test(`
+            var a = ['a', 'b', 'c']; 
+            var hasSymbolProperty = false;
+            if(a.entries()[Symbol.iterator]()) {
+                hasSymbolProperty = true;
+            }
+            hasSymbolProperty
+        `, true)
 
 		test(`
             var iterator = [1, 2, 3]["Symbol(Symbol.iterator)"]();

--- a/array_test.go
+++ b/array_test.go
@@ -121,6 +121,13 @@ func TestArray_iterator(t *testing.T) {
         `, true)
 
 		test(`
+            var a = ['a', 'b', 'c'];
+            var iterator = a.entries();
+            var val = iterator.next().value[0]
+            val
+        `, 0)
+
+		test(`
             var iterator = [1, 2, 3]["Symbol(Symbol.iterator)"]();
 
             one = iterator.next().value

--- a/array_test.go
+++ b/array_test.go
@@ -105,7 +105,15 @@ func TestArray_iterator(t *testing.T) {
 		test, _ := test()
 
 		test(`
+            var a = ['a', 'b', 'c'];
+            var iterator = a.entries();
+
+            iterator.next().value + " " + iterator.next().value + " " + iterator.next().value
+		`, "0,a 1,b 2,c")
+
+		test(`
             var iterator = [1, 2, 3]["Symbol(Symbol.iterator)"]();
+
             one = iterator.next().value
             two = iterator.next().value
             three = iterator.next().value

--- a/builtin_array.go
+++ b/builtin_array.go
@@ -864,8 +864,12 @@ func builtinArray_entries(call FunctionCall) Value {
 	arrayItems := []Value{}
 	this := call.thisObject()
 	this.enumerate(false, func(name string) bool {
+		idx, err := strconv.Atoi(name)
+		if err != nil {
+			panic(call.runtime.panicTypeError())
+		}
 		arrayItems = append(arrayItems, toValue_object(call.runtime.newArrayOf([]Value{
-			toValue_string(name),
+			toValue_int(idx),
 			this.get(name),
 		})))
 		return true

--- a/builtin_array.go
+++ b/builtin_array.go
@@ -859,3 +859,88 @@ func builtinArray_reduceRight(call FunctionCall) Value {
 	}
 	panic(call.runtime.panicTypeError())
 }
+
+func builtinArray_entries(call FunctionCall) Value {
+	arrayItems := []Value{}
+	this := call.thisObject()
+	this.enumerate(false, func(name string) bool {
+		arrayItems = append(arrayItems, toValue_object(call.runtime.newArrayOf([]Value{
+			toValue_string(name),
+			this.get(name),
+		})))
+		return true
+	})
+
+	next_function := &_object{
+		runtime:     call.runtime,
+		class:       "Function",
+		objectClass: _classObject,
+		prototype:   call.runtime.global.FunctionPrototype,
+		extensible:  true,
+		property: map[string]_property{
+			"length": {
+				mode: 0,
+				value: Value{
+					kind:  valueNumber,
+					value: 0,
+				},
+			},
+		},
+		propertyOrder: []string{
+			"length",
+		},
+		value: _nativeFunctionObject{
+			name: "next",
+			call: builtinArrayIterator_next(arrayItems),
+		},
+	}
+
+	entriesIterator := &_object{
+		runtime:     call.runtime,
+		class:       "Function",
+		objectClass: _classObject,
+		prototype:   call.runtime.global.FunctionPrototype,
+		extensible:  true,
+		property: map[string]_property{
+			"length": _property{
+				mode: 0,
+				value: Value{
+					kind:  valueNumber,
+					value: 0,
+				},
+			},
+		},
+		propertyOrder: []string{
+			"length",
+		},
+		value: _nativeFunctionObject{
+			name: "values",
+			call: builtinArray_entries,
+		},
+	}
+
+	return toValue_object(&_object{
+		runtime:     call.runtime,
+		class:       "Iterator",
+		objectClass: _classObject,
+		prototype:   call.runtime.global.ObjectPrototype,
+		extensible:  true,
+		value:       nil,
+		property: map[string]_property{
+			"next": {
+				mode: 0101,
+				value: Value{
+					kind:  valueObject,
+					value: next_function,
+				},
+			},
+			symbolIteratorTagPropertyName: _property{
+				mode: 0101,
+				value: Value{
+					kind:  valueObject,
+					value: entriesIterator,
+				},
+			},
+		},
+	})
+}

--- a/inline.go
+++ b/inline.go
@@ -1801,6 +1801,29 @@ func _newContext(runtime *_runtime) {
 				call: builtinArray_isArray,
 			},
 		}
+		entries_function := &_object{
+			runtime:     runtime,
+			class:       "Function",
+			objectClass: _classObject,
+			prototype:   runtime.global.FunctionPrototype,
+			extensible:  true,
+			property: map[string]_property{
+				"length": _property{
+					mode: 0,
+					value: Value{
+						kind:  valueNumber,
+						value: 1,
+					},
+				},
+			},
+			propertyOrder: []string{
+				"length",
+			},
+			value: _nativeFunctionObject{
+				name: "entries",
+				call: builtinArray_entries,
+			},
+		}
 		runtime.global.ArrayPrototype = &_object{
 			runtime:     runtime,
 			class:       "Array",
@@ -1984,6 +2007,13 @@ func _newContext(runtime *_runtime) {
 						value: reduceRight_function,
 					},
 				},
+				"entries": _property{
+					mode: 0101,
+					value: Value{
+						kind:  valueObject,
+						value: entries_function,
+					},
+				},
 			},
 			propertyOrder: []string{
 				"length",
@@ -2008,6 +2038,7 @@ func _newContext(runtime *_runtime) {
 				"filter",
 				"reduce",
 				"reduceRight",
+				"entries",
 			},
 		}
 		runtime.global.Array = &_object{


### PR DESCRIPTION
Added support for `Array.Prototype.entries`

`iterator.next().value` returns an array of length 2, which includes the `[index, element]` pair